### PR TITLE
Dependabot: keep GitHub Actions & Docker images up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directory: '/'
+    schedule:
+      interval: weekly


### PR DESCRIPTION
When going to production, we should also consider pinning down all images to a digest, so that we (can) have reproducible deployment.