### PR TITLE
Disable feed link_zurich

### DIFF
--- a/etc/lamassu/feedproviders.yml
+++ b/etc/lamassu/feedproviders.yml
@@ -153,12 +153,17 @@ lamassu:
       url: "https://data.lime.bike/api/partners/v2/gbfs/zug/gbfs.json"
       language: en
     # Link CH
-    - systemId: Link_Zurich
-      operatorId: LNK:Operator:link
-      operatorName: Link
-      codespace: LNK
-      url: "https://mds.linkyour.city/gbfs/ch_zurich/gbfs.json"
-      language: en
+    # - systemId: link_zurich
+      # operatorId: LNK:Operator:link
+      # operatorName: Link
+      # codespace: LNK
+      # language: en
+      # invalid feed: endpoints return error message, instead they should return empty collections or not be included in gbfs.json
+      # Suggestion:
+      # Get provider to fix data, or provide dummy data e.g. via transformer-proxy
+      # https://mds.linkyour.city/gbfs/2.2/ch_zurich/system_pricing_plans.json
+      # https://mds.linkyour.city/gbfs/2.2/ch_zurich/geofencing_zones.json
+      # url: "https://mds.linkyour.city/gbfs/ch_zurich/gbfs.json"
     # Nexbike CH
     - systemId: nextbike_ch
       operatorId: NBK:Operator:nextbike


### PR DESCRIPTION
This PR disables erroneous feed link_zurich. See #19 for background.