### PR TITLE
Add park-api layer to geoserver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -228,12 +228,16 @@ services:
       # kartoza/geoserver maps PROXY_BASE_URL_PARAMETRIZATION to ALLOW_ENV_PARAMETRIZATION, see https://github.com/kartoza/docker-geoserver/blob/844c7a26acd1687358c821ea73117a721f25f7b6/scripts/entrypoint.sh#L72
       - PROXY_BASE_URL_PARAMETRIZATION=true
       # The following parameters are *not* picked up by kartoza/geoserver, but instead passed through as "regular" env vars, and then read by Geoserver whenever one of the config files references them.
-      - PGBOUNCER_POSTGRES_USER=${PGBOUNCER_POSTGRES_USER:?missing/empty $PGBOUNCER_POSTGRES_USER}
-      - PGBOUNCER_POSTGRES_PASSWORD=${PGBOUNCER_POSTGRES_PASSWORD:?missing/empty $PGBOUNCER_POSTGRES_PASSWORD}
+      - PGBOUNCER_POSTGRES_USER=${PGBOUNCER_POSTGRES_USER:?missing/empty $$PGBOUNCER_POSTGRES_USER}
+      - PGBOUNCER_POSTGRES_PASSWORD=${PGBOUNCER_POSTGRES_PASSWORD:?missing/empty $$PGBOUNCER_POSTGRES_PASSWORD}
+      - PARK_API_POSTGRES_PASSWORD=${PARK_API_POSTGRES_PASSWORD?missing/empty $$PARK_API_POSTGRES_PASSWORD}
     depends_on:
       pgbouncer:
         # For sharing & transit layers
-        condition: service_healthy     
+        condition: service_healthy
+      park-api-db:
+        # For parking_sites layer
+        condition: service_healthy
     healthcheck:
       test: "curl -fsS -o /dev/null -u '${GEOSERVER_ADMIN_USER}':'${GEOSERVER_ADMIN_PASSWORD}' http://localhost:8080/geoserver/rest/about/version.xml"
       interval: 0m15s

--- a/etc/geoserver/workspaces/MobiData-BW/park-api-db/datastore.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/park-api-db/datastore.xml
@@ -1,0 +1,43 @@
+<dataStore>
+  <id>DataStoreInfoImpl--5bcdf8b:18bc88075ee:-7ffb</id>
+  <name>park-api-db</name>
+  <type>PostGIS</type>
+  <enabled>true</enabled>
+  <workspace>
+    <id>WorkspaceInfoImpl--48f676ef:18997a59df5:-7ff6</id>
+  </workspace>
+  <connectionParameters>
+    <entry key="schema">public</entry>
+    <entry key="Evictor run periodicity">300</entry>
+    <entry key="Max open prepared statements">50</entry>
+    <entry key="encode functions">true</entry>
+    <entry key="Batch insert size">1</entry>
+    <entry key="preparedStatements">false</entry>
+    <entry key="database">park-api</entry>
+    <entry key="host">park-api-db</entry>
+    <entry key="Loose bbox">true</entry>
+    <entry key="SSL mode">DISABLE</entry>
+    <entry key="Estimated extends">true</entry>
+    <entry key="fetch size">1000</entry>
+    <entry key="Expose primary keys">false</entry>
+    <entry key="validate connections">true</entry>
+    <entry key="Support on the fly geometry simplification">true</entry>
+    <entry key="Connection timeout">20</entry>
+    <entry key="create database">false</entry>
+    <entry key="Method used to simplify geometries">FAST</entry>
+    <entry key="port">5432</entry>
+    <entry key="passwd">${PARK_API_POSTGRES_PASSWORD}</entry>
+    <entry key="min connections">1</entry>
+    <entry key="dbtype">postgis</entry>
+    <entry key="namespace">mdbw</entry>
+    <entry key="max connections">10</entry>
+    <entry key="Evictor tests per run">3</entry>
+    <entry key="Test while idle">true</entry>
+    <entry key="user">park-api</entry>
+    <entry key="Max connection idle time">300</entry>
+  </connectionParameters>
+  <__default>false</__default>
+  <dateCreated>2023-11-13 11:48:31.64 UTC</dateCreated>
+  <dateModified>2023-11-13 11:48:53.391 UTC</dateModified>
+  <disableOnConnFailure>false</disableOnConnFailure>
+</dataStore>

--- a/etc/geoserver/workspaces/MobiData-BW/park-api-db/parking_sites/featuretype.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/park-api-db/parking_sites/featuretype.xml
@@ -1,0 +1,56 @@
+<featureType>
+  <id>FeatureTypeInfoImpl--5bcdf8b:18bc88075ee:-7ffa</id>
+  <name>parking_sites</name>
+  <nativeName>parking_site</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl--48f676ef:18997a59df5:-7ff5</id>
+  </namespace>
+  <title>parking_sites</title>
+  <keywords>
+    <string>features</string>
+    <string>parking_sites</string>
+  </keywords>
+  <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
+  DATUM[&quot;World Geodetic System 1984&quot;, 
+    SPHEROID[&quot;WGS 84&quot;, 6378137.0, 298.257223563, AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</nativeCRS>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>7.827393531799316</minx>
+    <maxx>10.004385948181152</maxx>
+    <miny>47.98236083984375</miny>
+    <maxy>49.49256896972656</maxy>
+    <crs>EPSG:4326</crs>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>7.827393531799316</minx>
+    <maxx>10.004385948181152</maxx>
+    <miny>47.98236083984375</miny>
+    <maxy>49.49256896972656</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="cachingEnabled">false</entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--5bcdf8b:18bc88075ee:-7ffb</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <simpleConversionEnabled>false</simpleConversionEnabled>
+  <internationalTitle/>
+  <internationalAbstract/>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/etc/geoserver/workspaces/MobiData-BW/park-api-db/parking_sites/layer.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/park-api-db/parking_sites/layer.xml
@@ -1,0 +1,22 @@
+<layer>
+  <name>parking_sites</name>
+  <id>LayerInfoImpl--5bcdf8b:18bc88075ee:-7ff9</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--3cb38bb4:18bc8a9af4b:-7ffb</id>
+  </defaultStyle>
+  <styles class="linked-hash-set">
+    <style>
+      <id>StyleInfoImpl--5bcdf8b:18bc88075ee:-7ff7</id>
+    </style>
+  </styles>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl--5bcdf8b:18bc88075ee:-7ffa</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+  <dateCreated>2023-11-13 11:50:05.514 UTC</dateCreated>
+  <dateModified>2023-11-13 13:07:22.798 UTC</dateModified>
+</layer>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_parking_site_default.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_parking_site_default.sld
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ogc="http://www.opengis.net/ogc" version="1.1.0" xmlns:se="http://www.opengis.net/se" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <NamedLayer>
+    <se:Name>parking_site</se:Name>
+    <UserStyle>
+      <se:Name>parking_site</se:Name>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:Name>Geschlossen</se:Name>
+          <se:Description>
+            <se:Title>Geschlossen</se:Title>
+          </se:Description>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:PropertyIsEqualTo>
+              <ogc:PropertyName>realtime_opening_status</ogc:PropertyName>
+              <ogc:Literal>CLOSED</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#ed0000</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke/>
+              </se:Mark>
+              <se:Size>7</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <se:Name>Keine Echtzeitdaten</se:Name>
+          <se:Description>
+            <se:Title>Keine Echtzeitdaten</se:Title>
+          </se:Description>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:PropertyIsNull>
+              <ogc:PropertyName>realtime_free_capacity</ogc:PropertyName>
+            </ogc:PropertyIsNull>
+          </ogc:Filter>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#0906cf</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke/>
+              </se:Mark>
+              <se:Size>7</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <se:Name>Parkplätze verfügbar</se:Name>
+          <se:Description>
+            <se:Title>Parkplätze verfügbar</se:Title>
+          </se:Description>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:And>
+              <ogc:PropertyIsGreaterThanOrEqualTo>
+                <ogc:Div>
+                  <ogc:Mul>
+                    <ogc:PropertyName>realtime_free_capacity</ogc:PropertyName>
+                    <ogc:Literal>1</ogc:Literal>
+                  </ogc:Mul>
+                  <ogc:Function name="if_then_else">
+                    <ogc:Function name="isNull">
+                      <ogc:PropertyName>realtime_capacity</ogc:PropertyName>
+                    </ogc:Function>
+                    <ogc:PropertyName>capacity</ogc:PropertyName>
+                    <ogc:PropertyName>realtime_capacity</ogc:PropertyName>
+                  </ogc:Function>
+                </ogc:Div>
+                <ogc:Literal>0.2</ogc:Literal>
+              </ogc:PropertyIsGreaterThanOrEqualTo>
+              <ogc:PropertyIsNotEqualTo>
+                <ogc:PropertyName>realtime_opening_status</ogc:PropertyName>
+                <ogc:Literal>CLOSED</ogc:Literal>
+              </ogc:PropertyIsNotEqualTo>
+            </ogc:And>
+          </ogc:Filter>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#059b02</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke/>
+              </se:Mark>
+              <se:Size>7</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <se:Name>Wenige Parkplätze verfügbar</se:Name>
+          <se:Description>
+            <se:Title>Wenige Parkplätze verfügbar</se:Title>
+          </se:Description>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:And>
+              <ogc:PropertyIsBetween>
+                <ogc:Div>
+                  <ogc:Mul>
+                    <ogc:PropertyName>realtime_free_capacity</ogc:PropertyName>
+                    <ogc:Literal>1</ogc:Literal>
+                  </ogc:Mul>
+                  <ogc:Function name="if_then_else">
+                    <ogc:Function name="isNull">
+                      <ogc:PropertyName>realtime_capacity</ogc:PropertyName>
+                    </ogc:Function>
+                    <ogc:PropertyName>capacity</ogc:PropertyName>
+                    <ogc:PropertyName>realtime_capacity</ogc:PropertyName>
+                  </ogc:Function>
+                </ogc:Div>
+                <ogc:LowerBoundary>
+                  <ogc:Literal>0.02</ogc:Literal>
+                </ogc:LowerBoundary>
+                <ogc:UpperBoundary>
+                  <ogc:Literal>0.2</ogc:Literal>
+                </ogc:UpperBoundary>        
+              </ogc:PropertyIsBetween>
+              <ogc:PropertyIsNotEqualTo>
+                <ogc:PropertyName>realtime_opening_status</ogc:PropertyName>
+                <ogc:Literal>CLOSED</ogc:Literal>
+              </ogc:PropertyIsNotEqualTo>
+            </ogc:And>
+          </ogc:Filter>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#dfab27</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke/>
+              </se:Mark>
+              <se:Size>7</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <se:Name>Keine oder sehr wenige Parkplätze verfügbar</se:Name>
+          <se:Description>
+            <se:Title>Keine oder sehr wenige Parkplätze verfügbar</se:Title>
+          </se:Description>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:And>
+              <ogc:PropertyIsGreaterThanOrEqualTo>
+                <ogc:PropertyName>realtime_free_capacity</ogc:PropertyName>
+                <ogc:Literal>0</ogc:Literal>
+              </ogc:PropertyIsGreaterThanOrEqualTo>
+              <ogc:PropertyIsLessThanOrEqualTo>
+                <ogc:Div>
+                  <ogc:Mul>
+                    <ogc:PropertyName>realtime_free_capacity</ogc:PropertyName>
+                    <ogc:Literal>1</ogc:Literal>
+                  </ogc:Mul>
+                  <ogc:Function name="if_then_else">
+                    <ogc:Function name="isNull">
+                      <ogc:PropertyName>realtime_capacity</ogc:PropertyName>
+                    </ogc:Function>
+                    <ogc:PropertyName>capacity</ogc:PropertyName>
+                    <ogc:PropertyName>realtime_capacity</ogc:PropertyName>
+                  </ogc:Function>
+                </ogc:Div>
+                <ogc:Literal>0.02</ogc:Literal>
+              </ogc:PropertyIsLessThanOrEqualTo>
+              <ogc:PropertyIsNotEqualTo>
+                <ogc:PropertyName>realtime_opening_status</ogc:PropertyName>
+                <ogc:Literal>CLOSED</ogc:Literal>
+              </ogc:PropertyIsNotEqualTo>
+            </ogc:And>
+          </ogc:Filter>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#ed0000</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke/>
+              </se:Mark>
+              <se:Size>7</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_parking_site_default.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_parking_site_default.xml
@@ -1,0 +1,14 @@
+<style>
+  <id>StyleInfoImpl--3cb38bb4:18bc8a9af4b:-7ffb</id>
+  <name>mdbw_parking_site_default</name>
+  <workspace>
+    <id>WorkspaceInfoImpl--48f676ef:18997a59df5:-7ff6</id>
+  </workspace>
+  <format>sld</format>
+  <languageVersion>
+    <version>1.1.0</version>
+  </languageVersion>
+  <filename>mdbw_parking_site_default.sld</filename>
+  <dateCreated>2023-11-13 13:06:48.287 UTC</dateCreated>
+  <dateModified>2023-11-13 14:42:37.883 UTC</dateModified>
+</style>


### PR DESCRIPTION
This PR
* adds a new parking_sites wms/wfs layer
* defines a default style `mdbw_parking_sites_default` which color codes parking_sites according to their remaining capacity/open state
* explicitly sets TIMEZONE for geoserver

Note: there is an upcoming pgbouncer PR. We should agree if all db connections should be handled via pgbouncer or only those which take a huge benefit. 