### PR TITLE
Add cors-headers for geoserver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -243,6 +243,9 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.geoserver.rule=PathPrefix(`/geoserver`)"
+      - "traefik.http.routers.geoserver.middlewares=geoserver-middleware"
+      - "traefik.http.middlewares.geoserver-middleware.headers.accesscontrolallowmethods=GET,OPTIONS,HEAD"
+      - "traefik.http.middlewares.geoserver-middleware.headers.accesscontrolallowheaders=*"
       - "traefik.http.services.geoserver.loadbalancer.server.port=8080"
     ports:
       - ${GEOSERVER_PORT}:8080


### PR DESCRIPTION
This PR adds CORS headers for the geoserver service. The kartoza base image sent them already, the geosolutions-it does not so we now handle this via traefik