### PR TITLE
Lamassu: graphiql basepath fix

### DIFF
--- a/etc/lamassu/application.properties
+++ b/etc/lamassu/application.properties
@@ -20,6 +20,7 @@ org.entur.lamassu.redis.slave.enabled=false
 
 # graphql starter
 graphql.graphiql.enabled=true
+graphql.graphiql.pageTitle=MobiData BW: Sharing API GraphiQL
 graphql.graphiql.basePath: /sharing/
 graphql.graphiql.endpoint.graphql: /sharing/graphql
 graphql.graphiql.endpoint.subscriptions: /sharing/subscriptions


### PR DESCRIPTION
This PR fixes a configuration issue introduced with updated lamassu. Now the graphiql basepath needs to be defined explicitly.