### PR TITLE
Add ocpdb layer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -335,12 +335,16 @@ services:
       - PGBOUNCER_POSTGRES_USER=${PGBOUNCER_POSTGRES_USER:?missing/empty}
       - PGBOUNCER_POSTGRES_PASSWORD=${PGBOUNCER_POSTGRES_PASSWORD:?missing/empty}
       - PARK_API_POSTGRES_PASSWORD=${PARK_API_POSTGRES_PASSWORD?missing/empty}
+      - OCPDB_POSTGRES_PASSWORD=${OCPDB_POSTGRES_PASSWORD:?missing/empty}
     depends_on:
       pgbouncer:
         # For sharing & transit layers
         condition: service_healthy
       park-api-db:
         # For parking_sites layer
+        condition: service_healthy
+      ocpdb-db:
+        # For ocpdb layer
         condition: service_healthy
     healthcheck:
       test: "curl -fsS -o /dev/null -u 'admin:${GEOSERVER_ADMIN_PASSWORD}' http://localhost:8080/geoserver/rest/about/version.xml"

--- a/etc/geoserver/workspaces/MobiData-BW/ocpdb-db/charge_points/featuretype.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/ocpdb-db/charge_points/featuretype.xml
@@ -1,0 +1,78 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-718ae34a:18c6e6b26ff:-7ffa</id>
+  <name>charge_points</name>
+  <nativeName>charge_points</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl--48f676ef:18997a59df5:-7ff5</id>
+  </namespace>
+  <title>E-Ladesäulen</title>
+  <keywords>
+    <string>charge_points</string>
+    <string>features</string>
+  </keywords>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>7.0</minx>
+    <maxx>10.5</maxx>
+    <miny>48.0</miny>
+    <maxy>52.0</maxy>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>7.0</minx>
+    <maxx>10.5</maxx>
+    <miny>48.0</miny>
+    <maxy>52.0</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>charge_points</name>
+        <sql>WITH location_power AS (SELECT location_id, max(max_electric_power) max_electric_power &#xd;
+                       FROM evse&#xd;
+                       JOIN connector&#xd;
+                         on evse.id = connector.evse_id&#xd;
+                      GROUP BY location_id)&#xd;
+&#xd;
+SELECT location.id, location.lat, location.lon, location.name, location.address, chargepoint_available_count, chargepoint_unknown_count, chargepoint_static_count, chargepoint_bike_count, max_electric_power, geometry&#xd;
+FROM location&#xd;
+LEFT JOIN (SELECT location_id, COUNT(es.id) as chargepoint_count,&#xd;
+                  SUM(CASE WHEN es.status = &apos;AVAILABLE&apos; THEN 1 ELSE 0 END) as chargepoint_available_count,&#xd;
+                  SUM(CASE WHEN es.status = &apos;UNKNOWN&apos; THEN 1 ELSE 0 END) as chargepoint_unknown_count,&#xd;
+                  SUM(CASE WHEN es.status = &apos;STATIC&apos; THEN 1 ELSE 0 END) as chargepoint_static_count,&#xd;
+                  SUM(CASE WHEN es.parking_restrictions &amp; 64 = 64 THEN 1 ELSE 0 END) as chargepoint_bike_count &#xd;
+             FROM location l&#xd;
+             JOIN evse es&#xd;
+               ON l.id =  es.location_id &#xd;
+            GROUP BY location_id) AS cp&#xd;
+  ON cp.location_id = location.id&#xd;
+LEFT JOIN location_power lp&#xd;
+       ON lp.location_id = location.id
+</sql>
+        <escapeSql>false</escapeSql>
+        <geometry>
+          <name>geometry</name>
+          <type>Point</type>
+          <srid>-1</srid>
+        </geometry>
+      </virtualTable>
+    </entry>
+    <entry key="cachingEnabled">false</entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl-718ae34a:18c6e6b26ff:-7ffb</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <simpleConversionEnabled>false</simpleConversionEnabled>
+  <internationalTitle/>
+  <internationalAbstract/>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/etc/geoserver/workspaces/MobiData-BW/ocpdb-db/charge_points/layer.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/ocpdb-db/charge_points/layer.xml
@@ -1,0 +1,17 @@
+<layer>
+  <name>charge_points</name>
+  <id>LayerInfoImpl-718ae34a:18c6e6b26ff:-7ff9</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--68bb822d:18c8eaa44d1:-74a0</id>
+  </defaultStyle>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-718ae34a:18c6e6b26ff:-7ffa</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+  <dateCreated>2023-12-15 18:21:03.51 UTC</dateCreated>
+  <dateModified>2023-12-21 23:27:33.143 UTC</dateModified>
+</layer>

--- a/etc/geoserver/workspaces/MobiData-BW/ocpdb-db/datastore.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/ocpdb-db/datastore.xml
@@ -1,0 +1,44 @@
+<dataStore>
+  <id>DataStoreInfoImpl-718ae34a:18c6e6b26ff:-7ffb</id>
+  <name>ocpdb-db</name>
+  <description>OpenChargePoint Database</description>
+  <type>PostGIS</type>
+  <enabled>true</enabled>
+  <workspace>
+    <id>WorkspaceInfoImpl--48f676ef:18997a59df5:-7ff6</id>
+  </workspace>
+  <connectionParameters>
+    <entry key="schema">public</entry>
+    <entry key="Evictor run periodicity">300</entry>
+    <entry key="Max open prepared statements">50</entry>
+    <entry key="encode functions">true</entry>
+    <entry key="Batch insert size">1</entry>
+    <entry key="preparedStatements">false</entry>
+    <entry key="database">ocpdb</entry>
+    <entry key="host">ocpdb-db</entry>
+    <entry key="Loose bbox">true</entry>
+    <entry key="SSL mode">DISABLE</entry>
+    <entry key="Estimated extends">true</entry>
+    <entry key="fetch size">1000</entry>
+    <entry key="Expose primary keys">false</entry>
+    <entry key="validate connections">true</entry>
+    <entry key="Support on the fly geometry simplification">true</entry>
+    <entry key="Connection timeout">20</entry>
+    <entry key="create database">false</entry>
+    <entry key="Method used to simplify geometries">FAST</entry>
+    <entry key="port">5432</entry>
+    <entry key="passwd">${OCPDB_API_POSTGRES_PASSWORD}</entry>
+    <entry key="min connections">1</entry>
+    <entry key="dbtype">postgis</entry>
+    <entry key="namespace">mdbw</entry>
+    <entry key="max connections">10</entry>
+    <entry key="Evictor tests per run">3</entry>
+    <entry key="Test while idle">true</entry>
+    <entry key="user">ocpdb</entry>
+    <entry key="Max connection idle time">300</entry>
+  </connectionParameters>
+  <__default>false</__default>
+  <dateCreated>2023-12-15 17:15:03.113 UTC</dateCreated>
+  <dateModified>2023-12-15 17:15:22.773 UTC</dateModified>
+  <disableOnConnFailure>false</disableOnConnFailure>
+</dataStore>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_charge_points_default.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_charge_points_default.sld
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ogc="http://www.opengis.net/ogc" version="1.1.0" xmlns:se="http://www.opengis.net/se" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <NamedLayer>
+    <se:Name>charge_point</se:Name>
+    <UserStyle>
+      <se:Name>charge_point</se:Name>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:Name>Ladesäule</se:Name>
+          <se:Description>
+            <se:Title>Ladesäule</se:Title>
+          </se:Description>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:PropertyIsLessThanOrEqualTo>
+              <ogc:PropertyName>max_electric_power</ogc:PropertyName>
+              <ogc:Literal>22000</ogc:Literal>
+            </ogc:PropertyIsLessThanOrEqualTo>
+          </ogc:Filter>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#08a4a7</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke/>
+              </se:Mark>
+              <se:Size>7</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <se:Name>Schnellladesäule</se:Name>
+          <se:Description>
+            <se:Title>Schnellladesäule</se:Title>
+          </se:Description>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:PropertyIsGreaterThan>
+              <ogc:PropertyName>max_electric_power</ogc:PropertyName>     
+              <ogc:Literal>22000</ogc:Literal>
+            </ogc:PropertyIsGreaterThan>
+          </ogc:Filter>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#91FFFF</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke/>
+              </se:Mark>
+              <se:Size>7</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>   
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_charge_points_default.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_charge_points_default.xml
@@ -1,0 +1,14 @@
+<style>
+  <id>StyleInfoImpl--68bb822d:18c8eaa44d1:-74a0</id>
+  <name>mdbw_charge_points_default</name>
+  <workspace>
+    <id>WorkspaceInfoImpl--48f676ef:18997a59df5:-7ff6</id>
+  </workspace>
+  <format>sld</format>
+  <languageVersion>
+    <version>1.1.0</version>
+  </languageVersion>
+  <filename>mdbw_charge_points_default.sld</filename>
+  <dateCreated>2023-12-21 23:26:31.191 UTC</dateCreated>
+  <dateModified>2023-12-21 23:26:49.212 UTC</dateModified>
+</style>


### PR DESCRIPTION
This PR adds an ocpdb layer to geoserver

Charge points with a max_capacity <= 22kw (`Ladesäulen`) are rendered in darker cyan, > 22kw (`Schnellladesäulen`) in brighter cyan:
 
<img width="451" alt="image" src="https://github.com/mobidata-bw/ipl-orchestration/assets/2187389/fbc95e5d-d672-4a84-b95d-e9c1ba903dee">
