### PR TITLE
Extract CORS settings to traefik config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,9 +104,6 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.well-known-uris.rule=PathPrefix(`/.well-known/`) || Path(`/robots.txt`)"
-      - "traefik.http.routers.well-known-uris.middlewares=well-known-uris-middleware"
-      - "traefik.http.middlewares.well-known-uris-middleware.headers.accesscontrolallowmethods=GET,OPTIONS,HEAD"
-      - "traefik.http.middlewares.well-known-uris-middleware.headers.accesscontrolallowheaders=*"
       - "traefik.http.services.well-known-uris.loadbalancer.server.port=80"
 
   goaccess:
@@ -174,10 +171,8 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.caddy.rule=PathPrefix(`/datasets`)"
-      - "traefik.http.routers.caddy.middlewares=caddy-middleware-1,caddy-middleware-2"
+      - "traefik.http.routers.caddy.middlewares=caddy-middleware-1"
       - "traefik.http.middlewares.caddy-middleware-1.stripprefix.prefixes=/datasets"
-      - "traefik.http.middlewares.caddy-middleware-2.headers.accesscontrolallowmethods=GET,OPTIONS,HEAD"
-      - "traefik.http.middlewares.caddy-middleware-2.headers.accesscontrolallowheaders=*"
       - "traefik.http.services.caddy.loadbalancer.server.port=80"
 
   # This service requests non-standard sharing provider APIs and generates
@@ -295,9 +290,6 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.geoserver.rule=PathPrefix(`/geoserver`)"
-      - "traefik.http.routers.geoserver.middlewares=geoserver-middleware"
-      - "traefik.http.middlewares.geoserver-middleware.headers.accesscontrolallowmethods=GET,OPTIONS,HEAD"
-      - "traefik.http.middlewares.geoserver-middleware.headers.accesscontrolallowheaders=*"
       - "traefik.http.services.geoserver.loadbalancer.server.port=8080"
     ports:
       - ${GEOSERVER_PORT}:8080

--- a/etc/traefik/allow-cors-including-post.yml
+++ b/etc/traefik/allow-cors-including-post.yml
@@ -1,0 +1,13 @@
+http:
+  middlewares:
+    allow-cors-including-post:
+      # NOTE: we enable CORS for all services (geoserver, etc) all origins (e.g. www.mobidata.de) 
+      # AND all hosts (api.mobiata-bw.de as well as VPN internal IP addresses)
+      # The CORS headers should be set at the publicly provided mobidata-bw reverse proxy instead.
+      headers:
+        accesscontrolallowmethods:
+          - GET
+          - POST
+          - OPTIONS
+          - HEAD
+        accesscontrolalloworiginlist: "*"

--- a/etc/traefik/traefik.yml
+++ b/etc/traefik/traefik.yml
@@ -32,6 +32,8 @@ entryPoints:
         - no-mime-sniff@file
         # enable response compression by default
         - compression@file
+        # enable CORS including POST by default
+        - allow-cors-including-post@file
       # redirect all `http:` requests to `https:`
       # todo: only do this in production
       # redirections:


### PR DESCRIPTION
This PR corrects treafik config option from `accesscontrolallowheader` to `accesscontrolalloworiginlist` and extracts them to the traefik config.

For Geoserver, POST is added to allowed methods also, as i.e. WFS requests might be request via `POST`.

Fixes #72 

Note: this is only a temporary fix and should better be done by the reverse proxy.