### PR TITLE
Lamassu: config fixes

### DIFF
--- a/etc/lamassu/feedproviders.yml
+++ b/etc/lamassu/feedproviders.yml
@@ -449,8 +449,8 @@ lamassu:
       language: en
     # Share Birrer CH
     - systemId: share_birrer_ch
-      operatorId: NBK:Operator:share_birrer_ag
-      operatorName: Share Birrer A
+      operatorId: SBA:Operator:share_birrer_ag
+      operatorName: Share Birrer AG
       codespace: SBA
       url: "https://www.share-birrer.ch/gbfs/gbfs.json"
       language: de


### PR DESCRIPTION
This PR fixes two lamassu config issues

* nextbike_ch is now requested via proxy (using http instead of https) (related: https://github.com/mobidata-bw/ipl-proxy/pull/39)
* Share Birrer AG's operatorId codespace and a typo in operatorName is fixed.