### PR TITLE
Use PROXY_BASE_URL env instead of config setting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -301,7 +301,7 @@ services:
       - GEOSERVER_DATA_DIR_CUSTOM=/var/geoserver/datadir_template/
       - GEOSERVER_LOGGING_PROFILE=${GEOSERVER_LOGGING_PROFILE}
       - GEOSERVER_CSRF_WHITELIST=${GEOSERVER_CSRF_WHITELIST:?missing/empty}
-      - GEOSERVER_PROXY_BASE_URL=${GEOSERVER_PROXY_BASE_URL:?missing/empty}
+      - PROXY_BASE_URL=${GEOSERVER_PROXY_BASE_URL:?missing/empty}
       # All we want to do is set user.timezone and DALLOW_ENV_PARAMETRIZATION. Due to https://github.com/geosolutions-it/docker-geoserver/issues/133
       # we currently need to pass in all default properties already defined in the dockerfile
       - JAVA_OPTS= >-

--- a/etc/geoserver/global.xml
+++ b/etc/geoserver/global.xml
@@ -40,7 +40,7 @@
     <showCreatedTimeColumnsInAdminList>false</showCreatedTimeColumnsInAdminList>
     <showModifiedTimeColumnsInAdminList>false</showModifiedTimeColumnsInAdminList>
     <useHeadersProxyURL>false</useHeadersProxyURL>
-    <proxyBaseUrl>${GEOSERVER_PROXY_BASE_URL}</proxyBaseUrl>
+    <proxyBaseUrl></proxyBaseUrl>
   </settings>
   <jai>
     <allowInterpolation>false</allowInterpolation>


### PR DESCRIPTION
This PR works around an issue when geoserver seems not to use the protocol defined in the config via an env variable (`GEOSERVER_PROXY_BASE_URL` in our case).

Instead, geoserver's standard env var `PROXY_BASE_URL` is set directly, so there is no need to supply it via config.