### PR TITLE
disable park-api heilbronn

### DIFF
--- a/etc/park-api/config.yaml
+++ b/etc/park-api/config.yaml
@@ -2,7 +2,8 @@ PARK_API_CONVERTER:
   - ulm
   - freiburg
   - heidelberg
-  - heilbronn
+  # Disable Heilbronn as long as legal status is unclear
+  # - heilbronn
   # Karlsruhe currently fails, see https://github.com/ParkenDD/ParkAPI2-sources/issues/40
   # - karlsruhe
   - mannheim


### PR DESCRIPTION
This disables heilbronn as the legal status of the data is unclear.