### PR TITLE
bash as park-api shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ docker-up: init
 .PHONY: docker-up-detached
 docker-up-detached: init
 	$(DOCKER_COMPOSE) up --detach --wait --wait-timeout 120 $(SERVICE)
-	# Reload geoserver config. Might fail with service "geoserver" 
+	# Reload geoserver config. Might fail with service "geoserver"
 	# is not running if geoserver has not yet been started. This can be ignored
 	$(DOCKER_COMPOSE) exec geoserver /usr/local/bin/geoserver-rest-reload.sh || true
 
@@ -132,5 +132,5 @@ park-api-upgrade:
 
 .PHONY: park-api-shell
 park-api-shell:
-	$(DOCKER_COMPOSE) exec park-api-flask /bin/sh
+	$(DOCKER_COMPOSE) exec park-api-flask /bin/bash
 


### PR DESCRIPTION
As park-api is based on Ubuntu, bash is available and more comfortable.