### PR TITLE
nextbike Ortenaukreis feed replaces Lahr and Offenburg

### DIFF
--- a/etc/lamassu/feedproviders.yml
+++ b/etc/lamassu/feedproviders.yml
@@ -78,36 +78,27 @@ lamassu:
     - systemId: nextbike_fg
       operatorId: NBK:Operator:nextbike
       operatorName: Nextbike
-      codespace: NBF
+      codespace: NBK
       url: "http://gbfs.nextbike.net/maps/gbfs/v2/nextbike_fg/gbfs.json"
       language: de
     - systemId: nextbike_ds
       operatorId: NBK:Operator:nextbike
       operatorName: Nextbike
-      codespace: NBD
+      codespace: NBK
       url: "http://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ds/gbfs.json"
       language: de
     - systemId: nextbike_vn
       operatorId: NBK:Operator:nextbike
       operatorName: Nextbike
-      codespace: NBV
+      codespace: NBK
       url: "http://gbfs.nextbike.net/maps/gbfs/v2/nextbike_vn/gbfs.json"
       language: de
-      # Offenburg currently not available(?). Request sent to nextbike 2023-07-25
-    #  - systemId: nextbike_dl
-    #    operatorId: NBK:Operator:nextbike
-    #    operatorName: Nextbike
-    #    codespace: NBK
-    #    url: "https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_dl/gbfs.json"
-    #    language: de
-    # Lahr currently not available(?). Request sent to nextbike 2023-07-25
-    #  - systemId: nextbike_lr
-    #    operatorId: NBK:Operator:nextbike
-    #    operatorName: Nextbike
-    #    codespace: NBK
-    #    url: "https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_lr/gbfs.json"
-    #    language: de
-    # Bolt DE
+    - systemId: nextbike_eh
+      operatorId: NBK:Operator:nextbike
+      operatorName: Nextbike
+      codespace: NBK
+      url: "http://gbfs.nextbike.net/maps/gbfs/v2/nextbike_eh/gbfs.json"
+      language: de
     - systemId: bolt_karlsruhe
       operatorId: BLT:Operator:bolt
       operatorName: Bolt

--- a/etc/lamassu/feedproviders.yml
+++ b/etc/lamassu/feedproviders.yml
@@ -78,25 +78,25 @@ lamassu:
     - systemId: nextbike_fg
       operatorId: NBK:Operator:nextbike
       operatorName: Nextbike
-      codespace: NBK
+      codespace: NBF
       url: "http://gbfs.nextbike.net/maps/gbfs/v2/nextbike_fg/gbfs.json"
       language: de
     - systemId: nextbike_ds
       operatorId: NBK:Operator:nextbike
       operatorName: Nextbike
-      codespace: NBK
+      codespace: NBD
       url: "http://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ds/gbfs.json"
       language: de
     - systemId: nextbike_vn
       operatorId: NBK:Operator:nextbike
       operatorName: Nextbike
-      codespace: NBK
+      codespace: NBV
       url: "http://gbfs.nextbike.net/maps/gbfs/v2/nextbike_vn/gbfs.json"
       language: de
     - systemId: nextbike_eh
       operatorId: NBK:Operator:nextbike
       operatorName: Nextbike
-      codespace: NBK
+      codespace: NBE
       url: "http://gbfs.nextbike.net/maps/gbfs/v2/nextbike_eh/gbfs.json"
       language: de
     - systemId: bolt_karlsruhe


### PR DESCRIPTION
in addition, the same codespace is now used for all nextbike feed