### PR TITLE
RadVIS download

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -82,3 +82,7 @@ PARK_API_SECRET_KEY=secret
 
 # Public ParkAPI URL
 PARK_API_PROJECT_URL=https://api.mobidata-bw.de/park-api
+
+# RadVIS credentials
+RADVIS_WFS_USER=user
+RADVIS_WFS_PASSWORD=secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -401,6 +401,9 @@ services:
       - IPL_GTFS_IMPORTER_HOST_GTFS_OUTPUT_DIR=${PWD}/var/gtfs/
       # directory where datasets should stored for publishing (Note: should be mounted as volume)
       - WWW_ROOT_DIR=/var/www/
+      # RadVIS Download credentials
+      - RADVIS_WFS_USER=${RADVIS_WFS_USER:?missing/empty}
+      - RADVIS_WFS_PASSWORD=${RADVIS_WFS_PASSWORD:?missing/empty}
     volumes:
       # Make docker API accessible so we can start containers in jobs
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -399,11 +399,15 @@ services:
       # Required to mount volumes for docker-in-docker executions
       - IPL_GTFS_IMPORTER_HOST_CUSTOM_SCRIPTS_DIR=${PWD}/etc/gtfs/
       - IPL_GTFS_IMPORTER_HOST_GTFS_OUTPUT_DIR=${PWD}/var/gtfs/
+      # directory where datasets should stored for publishing (Note: should be mounted as volume)
+      - WWW_ROOT_DIR=/var/www/
     volumes:
       # Make docker API accessible so we can start containers in jobs
       - /var/run/docker.sock:/var/run/docker.sock
       # mount storage dir so logs/assets are written to volume shared with dagaster-daemon/dagit
       - ./var/dagster/storage/:/opt/dagster/dagster_home/storage/
+      # mount www dir to republish downloaded datasets
+      - ./var/www/datasets/:/var/www/
     depends_on:
         pgbouncer:
           condition: service_healthy


### PR DESCRIPTION
This PR

* provides environment variables for upcoming dagster PR https://github.com/mobidata-bw/ipl-dagster-pipeline/pull/82
* configures dagster to store downloaded dataset into directory which is served by caddy

Note: before merging, the credentials should be configured for all enviroments, see https://github.com/mobidata-bw/ipl-ansible/pull/35