### PR TITLE
Add RadVIS WMS/WFS Layer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,11 @@ docker-ps:
 reload-geoserver:
 	$(DOCKER_COMPOSE) exec geoserver /usr/local/bin/geoserver-rest-reload.sh
 
+# Syncs Geoserver's var workspace dir to etc, excluding the overwritten datastore.xml
+.PHONY: prepare-geoserver-workspace-for-commit
+prepare-geoserver-workspace-for-commit:
+	rsync -av --exclude='*/datastore.xml' var/geoserver/datadir/workspaces etc/geoserver
+
 # GTFS data management
 # --------------------
 

--- a/etc/geoserver/workspaces/MobiData-BW/ipl-db/radvis_cycle_network/featuretype.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/ipl-db/radvis_cycle_network/featuretype.xml
@@ -1,0 +1,80 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-16b18166:18b6756af37:-7adc</id>
+  <name>radvis_cycle_network</name>
+  <nativeName>cycle_network</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl--48f676ef:18997a59df5:-7ff5</id>
+  </namespace>
+  <title>RadNETZ-BW</title>
+  <keywords>
+    <string>features</string>
+    <string>RadNETZ-BW</string>
+  </keywords>
+  <nativeCRS class="projected">PROJCS[&quot;ETRS89 / UTM zone 32N&quot;, 
+  GEOGCS[&quot;ETRS89&quot;, 
+    DATUM[&quot;European Terrestrial Reference System 1989&quot;, 
+      SPHEROID[&quot;GRS 1980&quot;, 6378137.0, 298.257222101, AUTHORITY[&quot;EPSG&quot;,&quot;7019&quot;]], 
+      TOWGS84[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], 
+      AUTHORITY[&quot;EPSG&quot;,&quot;6258&quot;]], 
+    PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+    UNIT[&quot;degree&quot;, 0.017453292519943295], 
+    AXIS[&quot;Geodetic longitude&quot;, EAST], 
+    AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;4258&quot;]], 
+  PROJECTION[&quot;Transverse_Mercator&quot;, AUTHORITY[&quot;EPSG&quot;,&quot;9807&quot;]], 
+  PARAMETER[&quot;central_meridian&quot;, 9.0], 
+  PARAMETER[&quot;latitude_of_origin&quot;, 0.0], 
+  PARAMETER[&quot;scale_factor&quot;, 0.9996], 
+  PARAMETER[&quot;false_easting&quot;, 500000.0], 
+  PARAMETER[&quot;false_northing&quot;, 0.0], 
+  UNIT[&quot;m&quot;, 1.0], 
+  AXIS[&quot;Easting&quot;, EAST], 
+  AXIS[&quot;Northing&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;25832&quot;]]</nativeCRS>
+  <srs>EPSG:25832</srs>
+  <nativeBoundingBox>
+    <minx>388441.63</minx>
+    <maxx>605596.8</maxx>
+    <miny>5266225.82</miny>
+    <maxy>5514689.85</maxy>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>7.450590293831204</minx>
+    <maxx>10.466640224687547</maxx>
+    <miny>47.53987254054931</miny>
+    <maxy>49.78466331045743</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>cycle_network</name>
+        <sql>Select * from Streckenabschnitt
+</sql>
+        <escapeSql>false</escapeSql>
+        <geometry>
+          <name>wkb_geometry</name>
+          <type>LineString</type>
+          <srid>25832</srid>
+        </geometry>
+      </virtualTable>
+    </entry>
+    <entry key="cachingEnabled">true</entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--48f676ef:18997a59df5:-7ff0</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <simpleConversionEnabled>false</simpleConversionEnabled>
+  <internationalTitle/>
+  <internationalAbstract/>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/etc/geoserver/workspaces/MobiData-BW/ipl-db/radvis_cycle_network/layer.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/ipl-db/radvis_cycle_network/layer.xml
@@ -1,0 +1,17 @@
+<layer>
+  <name>radvis_cycle_network</name>
+  <id>LayerInfoImpl-16b18166:18b6756af37:-7adb</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--4537d375:18dec89cdf2:-452b</id>
+  </defaultStyle>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-16b18166:18b6756af37:-7adc</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+  <dateCreated>2023-10-25 15:39:36.504 UTC</dateCreated>
+  <dateModified>2024-02-27 22:07:45.949 UTC</dateModified>
+</layer>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_radvis_cn_default.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_radvis_cn_default.sld
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>RadVIS Radnetze Baden-Württemberg</Name>
+    <UserStyle>
+      <FeatureTypeStyle>
+        <Rule>
+          <Name>Kommunales Netz</Name>
+          <Title>Kommunales Netz</Title>
+          <ogc:Filter>
+            <ogc:And>
+              <ogc:And>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>ext_bw_kommunetz</ogc:PropertyName>
+                  <ogc:Literal>1</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+                <ogc:Not>
+                  <ogc:PropertyIsEqualTo>
+                    <ogc:PropertyName>ext_bw_kreisnetz</ogc:PropertyName>
+                    <ogc:Literal>1</ogc:Literal>
+                  </ogc:PropertyIsEqualTo>
+                </ogc:Not>
+              </ogc:And>
+              <ogc:Not>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>ext_bw_landesnetz</ogc:PropertyName>
+                  <ogc:Literal>1</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+              </ogc:Not>
+            </ogc:And>
+          </ogc:Filter>
+          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#0020aa</CssParameter>
+              <CssParameter name="stroke-width">2</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+        <Rule>
+          <Name>Kreisnetz</Name>
+          <Title>Kreisnetzz</Title>
+          <ogc:Filter>
+            <ogc:And>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>ext_bw_kreisnetz</ogc:PropertyName>
+                <ogc:Literal>1</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+              <ogc:Not>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>ext_bw_landesnetz</ogc:PropertyName>
+                  <ogc:Literal>1</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+              </ogc:Not>
+            </ogc:And>
+          </ogc:Filter>
+          <MaxScaleDenominator>200000</MaxScaleDenominator>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#008001</CssParameter>
+              <CssParameter name="stroke-width">2</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+        <Rule>
+          <Name>RadNETZ-BW</Name>
+          <Title>RadNETZ-BW</Title>
+          <ogc:Filter>
+            <ogc:PropertyIsEqualTo>
+              <ogc:PropertyName>ext_bw_landesnetz</ogc:PropertyName>
+              <ogc:Literal>1</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#FF7F00</CssParameter>
+              <CssParameter name="stroke-width">3</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_radvis_cn_default.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_radvis_cn_default.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<style>
+  <id>StyleInfoImpl--4537d375:18dec89cdf2:-452b</id>
+  <name>mdbw_radvis_cn_default</name>
+  <workspace>
+    <id>WorkspaceInfoImpl--48f676ef:18997a59df5:-7ff6</id>
+  </workspace>
+  <format>sld</format>
+  <languageVersion>
+    <version>1.0.0</version>
+  </languageVersion>
+  <filename>mdbw_radvis_cn_default.sld</filename>
+  <dateCreated>2024-02-27 22:06:43.876 UTC</dateCreated>
+  <dateModified>2024-02-27 22:24:41.453 UTC</dateModified>
+</style>


### PR DESCRIPTION
This PR adds a RadVIS cycle network layer. 

Depending on zoom level, it shows the state's RadNETZ BW in yellow, additionally the district cycle networks in green and municipal cycle networks in blue.

<img width="304" alt="image" src="https://github.com/mobidata-bw/ipl-orchestration/assets/2187389/bdb7ffc1-a98f-4c33-8873-8071dcc925a5">
<img width="394" alt="image" src="https://github.com/mobidata-bw/ipl-orchestration/assets/2187389/55c69d57-d647-4785-a4d0-847017465f90">

Note: This PR is intended to be merged into main after branch `radvis-download` has been integrated.