### PR TITLE
Add Roadworks

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -86,3 +86,7 @@ PARK_API_PROJECT_URL=https://api.mobidata-bw.de/park-api
 # RadVIS credentials
 RADVIS_WFS_USER=user
 RADVIS_WFS_PASSWORD=secret
+
+# SVZBW DATEX2 Download URL
+ROADWORKS_SVZBW_DATEX2_DOWNLOAD_URL=https://url
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -404,6 +404,8 @@ services:
       # RadVIS Download credentials
       - RADVIS_WFS_USER=${RADVIS_WFS_USER:?missing/empty}
       - RADVIS_WFS_PASSWORD=${RADVIS_WFS_PASSWORD:?missing/empty}
+      # Roadworks download url
+      - ROADWORKS_SVZBW_DATEX2_DOWNLOAD_URL=${ROADWORKS_SVZBW_DATEX2_DOWNLOAD_URL:?missing/empty}
     volumes:
       # Make docker API accessible so we can start containers in jobs
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -279,6 +279,7 @@ services:
       - ./etc/geoserver/:/var/geoserver/datadir_template/
       # global.xml is written by geoserver before config reload, so we need to have it mounted already at start
       - ./etc/geoserver/global.xml:/var/geoserver/datadir/global.xml
+      - ./etc/geoserver/logging.xml:/var/geoserver/datadir/logging.xml
       - ./bin/geoserver/geoserver-rest-config.sh:/usr/local/bin/geoserver-rest-config.sh
       - ./bin/geoserver/geoserver-rest-reload.sh:/usr/local/bin/geoserver-rest-reload.sh
     labels:

--- a/etc/geoserver/workspaces/MobiData-BW/ipl-db/roadworks/featuretype.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/ipl-db/roadworks/featuretype.xml
@@ -1,0 +1,58 @@
+<featureType>
+  <id>FeatureTypeInfoImpl--2f417ac5:18e2df033ce:-7ff1</id>
+  <name>roadworks</name>
+  <nativeName>roadworks</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl--48f676ef:18997a59df5:-7ff5</id>
+  </namespace>
+  <title>Arbeitsstellen</title>
+  <keywords>
+    <string>features</string>
+    <string>roadworks</string>
+    <string>Arbeitsstellen</string>
+    <string>Baustellen</string>
+  </keywords>
+  <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
+  DATUM[&quot;World Geodetic System 1984&quot;, 
+    SPHEROID[&quot;WGS 84&quot;, 6378137.0, 298.257223563, AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</nativeCRS>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>7.58094596862793</minx>
+    <maxx>10.228989601135254</maxx>
+    <miny>47.58646011352539</miny>
+    <maxy>49.62147521972656</maxy>
+    <crs>EPSG:4326</crs>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>7.58094596862793</minx>
+    <maxx>10.228989601135254</maxx>
+    <miny>47.58646011352539</miny>
+    <maxy>49.62147521972656</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="cachingEnabled">false</entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--48f676ef:18997a59df5:-7ff0</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <simpleConversionEnabled>false</simpleConversionEnabled>
+  <internationalTitle/>
+  <internationalAbstract/>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/etc/geoserver/workspaces/MobiData-BW/ipl-db/roadworks/layer.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/ipl-db/roadworks/layer.xml
@@ -1,0 +1,17 @@
+<layer>
+  <name>roadworks</name>
+  <id>LayerInfoImpl--2f417ac5:18e2df033ce:-7ff0</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--2f417ac5:18e2df033ce:-7e89</id>
+  </defaultStyle>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl--2f417ac5:18e2df033ce:-7ff1</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+  <dateCreated>2024-03-11 14:39:41.522 UTC</dateCreated>
+  <dateModified>2024-03-11 14:50:34.854 UTC</dateModified>
+</layer>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_traffic_roadworks_default.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_traffic_roadworks_default.sld
@@ -8,10 +8,10 @@
       <FeatureTypeStyle>
         <Rule>
           <ogc:Filter>
-            <ogc:PropertyIsGreaterThan>
+            <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>direction</ogc:PropertyName>
               <ogc:Literal>BOTH_DIRECTIONS</ogc:Literal>
-            </ogc:PropertyIsGreaterThan>
+            </ogc:PropertyIsEqualTo>
           </ogc:Filter>
           <LineSymbolizer>
             <Stroke>
@@ -27,6 +27,147 @@
               <CssParameter name="stroke-dasharray">4 2</CssParameter>
             </Stroke>
           </LineSymbolizer>
+        </Rule>
+        <Rule>
+          <ogc:Filter>
+            <ogc:Not>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>direction</ogc:PropertyName>
+                <ogc:Literal>BOTH_DIRECTIONS</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+            </ogc:Not>
+          </ogc:Filter>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#ffffff</CssParameter>
+              <CssParameter name="stroke-width">3</CssParameter>
+              <CssParameter name="stroke-linecap">round</CssParameter>
+            </Stroke>
+            <PerpendicularOffset>2</PerpendicularOffset>
+          </LineSymbolizer>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#A93030</CssParameter>
+              <CssParameter name="stroke-width">2</CssParameter>
+              <CssParameter name="stroke-dasharray">4 2</CssParameter>
+            </Stroke>
+            <PerpendicularOffset>2</PerpendicularOffset>
+          </LineSymbolizer>
+        </Rule>
+        <Rule>
+          <!-- Einseitige Sperrungen Smybol -->
+          <ogc:Filter>
+            <ogc:And>
+              <ogc:Not>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>direction</ogc:PropertyName>
+                  <ogc:Literal>BOTH_DIRECTIONS</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+              </ogc:Not>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>type</ogc:PropertyName>
+                <ogc:Literal>ROAD_CLOSED</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+            </ogc:And>
+          </ogc:Filter>
+          <PointSymbolizer>
+            <Geometry>
+              <ogc:Function name="startPoint">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+            </Geometry>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#A93030</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>8</Size>
+            </Graphic>
+          </PointSymbolizer>
+          <PointSymbolizer>
+            <Geometry>
+              <ogc:Function name="startPoint">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+            </Geometry>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#ffffff</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>5</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+        <Rule>
+          <!-- Einseitige Nicht-Sperrungen Smybol -->
+          <ogc:Filter>
+            <ogc:And>
+              <ogc:Not>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>direction</ogc:PropertyName>
+                  <ogc:Literal>BOTH_DIRECTIONS</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+              </ogc:Not>
+              <ogc:Not>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>type</ogc:PropertyName>
+                  <ogc:Literal>ROAD_CLOSED</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+              </ogc:Not>
+            </ogc:And>
+          </ogc:Filter>
+          <PointSymbolizer>
+            <Geometry>
+              <ogc:Function name="startPoint">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+            </Geometry>
+            <Graphic>
+              <Mark>
+                <WellKnownName>triangle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#A93030</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>8</Size>
+            </Graphic>
+          </PointSymbolizer>
+          <PointSymbolizer>
+            <Geometry>
+              <ogc:Function name="startPoint">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+            </Geometry>
+            <Graphic>
+              <Mark>
+                <WellKnownName>triangle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#ffffff</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>3</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+        <Rule>
+          <!-- Beidseitige Sperrungen Smybol -->
+          <ogc:Filter>
+            <ogc:And>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>direction</ogc:PropertyName>
+                <ogc:Literal>BOTH_DIRECTIONS</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>type</ogc:PropertyName>
+                <ogc:Literal>ROAD_CLOSED</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+            </ogc:And>
+          </ogc:Filter>
           <PointSymbolizer>
             <Geometry>
               <ogc:Function name="interiorPoint">
@@ -61,60 +202,51 @@
           </PointSymbolizer>
         </Rule>
         <Rule>
+          <!-- Beidseitige Nicht-Sperrungen Smybol -->
           <ogc:Filter>
-            <ogc:Not>
-              <ogc:PropertyIsGreaterThan>
+            <ogc:And>
+              <ogc:PropertyIsEqualTo>
                 <ogc:PropertyName>direction</ogc:PropertyName>
                 <ogc:Literal>BOTH_DIRECTIONS</ogc:Literal>
-              </ogc:PropertyIsGreaterThan>
-            </ogc:Not>
+              </ogc:PropertyIsEqualTo>
+              <ogc:Not>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>type</ogc:PropertyName>
+                  <ogc:Literal>ROAD_CLOSED</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+              </ogc:Not>
+            </ogc:And>
           </ogc:Filter>
-          <LineSymbolizer>
-            <Stroke>
-              <CssParameter name="stroke">#ffffff</CssParameter>
-              <CssParameter name="stroke-width">3</CssParameter>
-              <CssParameter name="stroke-linecap">round</CssParameter>
-            </Stroke>
-            <PerpendicularOffset>2</PerpendicularOffset>
-          </LineSymbolizer>
-          <LineSymbolizer>
-            <Stroke>
-              <CssParameter name="stroke">#A93030</CssParameter>
-              <CssParameter name="stroke-width">2</CssParameter>
-              <CssParameter name="stroke-dasharray">4 2</CssParameter>
-            </Stroke>
-            <PerpendicularOffset>2</PerpendicularOffset>
-          </LineSymbolizer>
           <PointSymbolizer>
             <Geometry>
-              <ogc:Function name="startPoint">
+              <ogc:Function name="interiorPoint">
                 <ogc:PropertyName>geometry</ogc:PropertyName>
               </ogc:Function>
             </Geometry>
             <Graphic>
               <Mark>
-                <WellKnownName>circle</WellKnownName>
+                <WellKnownName>triangle</WellKnownName>
                 <Fill>
                   <CssParameter name="fill">#A93030</CssParameter>
                 </Fill>
               </Mark>
-              <Size>8</Size>
+              <Size>10</Size>
             </Graphic>
           </PointSymbolizer>
           <PointSymbolizer>
             <Geometry>
-              <ogc:Function name="startPoint">
+              <ogc:Function name="interiorPoint">
                 <ogc:PropertyName>geometry</ogc:PropertyName>
               </ogc:Function>
             </Geometry>
             <Graphic>
               <Mark>
-                <WellKnownName>circle</WellKnownName>
+                <WellKnownName>triangle</WellKnownName>
                 <Fill>
                   <CssParameter name="fill">#ffffff</CssParameter>
                 </Fill>
               </Mark>
-              <Size>5</Size>
+              <Size>8</Size>
             </Graphic>
           </PointSymbolizer>
         </Rule>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_traffic_roadworks_default.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_traffic_roadworks_default.sld
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>Arbeitsstellen</Name>
+    <UserStyle>
+      <Title>Arbeitsstelle</Title>
+      <Abstract></Abstract>
+      <FeatureTypeStyle>
+        <Rule>
+          <ogc:Filter>
+            <ogc:PropertyIsGreaterThan>
+              <ogc:PropertyName>direction</ogc:PropertyName>
+              <ogc:Literal>BOTH_DIRECTIONS</ogc:Literal>
+            </ogc:PropertyIsGreaterThan>
+          </ogc:Filter>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#ffffff</CssParameter>
+              <CssParameter name="stroke-width">5</CssParameter>
+              <CssParameter name="stroke-linecap">round</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#A93030</CssParameter>
+              <CssParameter name="stroke-width">3</CssParameter>
+              <CssParameter name="stroke-dasharray">4 2</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+          <PointSymbolizer>
+            <Geometry>
+              <ogc:Function name="interiorPoint">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+            </Geometry>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#A93030</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>8</Size>
+            </Graphic>
+          </PointSymbolizer>
+          <PointSymbolizer>
+            <Geometry>
+              <ogc:Function name="interiorPoint">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+            </Geometry>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#ffffff</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>5</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+        <Rule>
+          <ogc:Filter>
+            <ogc:Not>
+              <ogc:PropertyIsGreaterThan>
+                <ogc:PropertyName>direction</ogc:PropertyName>
+                <ogc:Literal>BOTH_DIRECTIONS</ogc:Literal>
+              </ogc:PropertyIsGreaterThan>
+            </ogc:Not>
+          </ogc:Filter>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#ffffff</CssParameter>
+              <CssParameter name="stroke-width">3</CssParameter>
+              <CssParameter name="stroke-linecap">round</CssParameter>
+            </Stroke>
+            <PerpendicularOffset>2</PerpendicularOffset>
+          </LineSymbolizer>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#A93030</CssParameter>
+              <CssParameter name="stroke-width">2</CssParameter>
+              <CssParameter name="stroke-dasharray">4 2</CssParameter>
+            </Stroke>
+            <PerpendicularOffset>2</PerpendicularOffset>
+          </LineSymbolizer>
+          <PointSymbolizer>
+            <Geometry>
+              <ogc:Function name="startPoint">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+            </Geometry>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#A93030</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>8</Size>
+            </Graphic>
+          </PointSymbolizer>
+          <PointSymbolizer>
+            <Geometry>
+              <ogc:Function name="startPoint">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+            </Geometry>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#ffffff</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>5</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_traffic_roadworks_default.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_traffic_roadworks_default.xml
@@ -1,0 +1,14 @@
+<style>
+  <id>StyleInfoImpl--2f417ac5:18e2df033ce:-7e89</id>
+  <name>mdbw_traffic_roadworks_default</name>
+  <workspace>
+    <id>WorkspaceInfoImpl--48f676ef:18997a59df5:-7ff6</id>
+  </workspace>
+  <format>sld</format>
+  <languageVersion>
+    <version>1.0.0</version>
+  </languageVersion>
+  <filename>mdbw_traffic_roadworks_default.sld</filename>
+  <dateCreated>2024-03-11 14:40:34.117 UTC</dateCreated>
+  <dateModified>2024-03-12 08:47:27.678 UTC</dateModified>
+</style>


### PR DESCRIPTION
This PR

* adds required env vars to the dagster pipeline container
* defines layers and a first style definition to visualize roadworks

it should be merged in conjunction with https://github.com/mobidata-bw/ipl-dagster-pipeline/pull/86.
Note: The styles will need to be refined further, i.e. distinguishing road closures vs constructions, current and future roadworks etc.
