### PR TITLE
gtfs-api: format PostGIS geography as JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Changes
 * GBFS Feeds (general): With Lamassu [v2024-06-17T13-28](https://github.com/entur/lamassu/blob/master/Changelog.md), we now support GBFSv3. To request feeds in the new GBFSv3 version, instead of `sharing/gbfs` use `sharing/gbfs/v3/manifest.json`. With this version, accessing feeds which are not yet retreived from upstream will return an http status 502 (BAD GATEWAY) instead of 404 (NOT FOUND). 
+- ⚠️ In the GTFS API (`/gtfs`), all [`geography`](https://postgis.net/docs/manual-3.4/using_postgis_dbmanagement.html#PostGIS_Geography)-based columns have been changed from a hex encoding of the PostGIS-specific binary representation to [GeoJSON](https://geojson.org). If you depend on the current format of `shape_pt_loc` in `/gtfs/shapes` or `stop_loc` in `/gtfs/stops`, you will have to adapt your code. For example, the `stop_loc` format of stop `de:08231:50_Parent` (*Pforzheim Hauptbahnhof*) changes from `"0101000020E6100000D28BDAFD2A68214003098A1F63724840"` to `{"type":"Point","coordinates":[8.703453,48.89365]}`.
 
 ### Fixes
 

--- a/etc/gtfs/sql.d/22-postgis-geography-to-json.sql
+++ b/etc/gtfs/sql.d/22-postgis-geography-to-json.sql
@@ -1,0 +1,9 @@
+-- Tell PostgreSQL that how to convert a PostGIS geography to a JSON string. PostgREST will pick this up when the user requested a JSON response.
+CREATE OR REPLACE FUNCTION _geography_as_json(geography)
+RETURNS json
+AS $$
+	SELECT ST_AsGeoJSON($1)::json;
+$$
+LANGUAGE SQL
+IMMUTABLE;
+CREATE CAST (geography AS json) WITH FUNCTION _geography_as_json(geography) AS IMPLICIT;


### PR DESCRIPTION
Currently, PostgREST just casts PostGIS `geography`s to `text`, which looks like this:

```shell
curl "https://api.mobidata-bw.de/gtfs/stops?stop_id=like.$(echo -n 'de:08231:50%' | url-encode)&limit=1" -H 'User-Agent: derhuerst' -H 'Accept: application/json' -fsSL | jq -r --tab '.[]'
```

```json
{
	"stop_id": "de:08231:50_Parent",
	"stop_code": null,
	"stop_name": "Pforzheim Hauptbahnhof",
	"stop_desc": null,
	"stop_loc": "0101000020E6100000D28BDAFD2A68214003098A1F63724840",
	"zone_id": null,
	"stop_url": null,
	"location_type": "station",
	"parent_station": null,
	"stop_timezone": null,
	"wheelchair_boarding": null,
	"level_id": null,
	"platform_code": null
}
```

This PR adds a cast to `json`, which PostgREST picks up automatically. **Note that this is a breaking change**.

```json
{
	"stop_id": "de:08231:50_Parent",
	"stop_code": null,
	"stop_name": "Pforzheim Hauptbahnhof",
	"stop_desc": null,
	"stop_loc": {
		"type": "Point",
		"coordinates": [
			8.703453,
			48.89365
		]
	},
	"zone_id": null,
	"stop_url": null,
	"location_type": "station",
	"parent_station": null,
	"stop_timezone": null,
	"wheelchair_boarding": null,
	"level_id": null,
	"platform_code": null
}
```