### PR TITLE
Add MOQO_API_TOKEN

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -32,6 +32,9 @@ VOI_PASSWORD=password
 # Url to the cantamen IXSI service. Note: this service is IP restricted
 CANTAMEN_IXSI_API_URL=http://example.org
 
+# Token for x2gbfs/stadtwerk_tauberfranken
+MOQO_API_TOKEN=token
+
 # A random password for pgbouncer clients (gtfs-api, geoserver, dagster, etc.)
 PGBOUNCER_POSTGRES_PASSWORD=secret
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,6 +185,7 @@ services:
       - VOI_USER=${VOI_USER:?missing/empty}
       - VOI_PASSWORD=${VOI_PASSWORD:?missing/empty}
       - CANTAMEN_IXSI_API_URL=${CANTAMEN_IXSI_API_URL:?missing/empty}
+      - MOQO_API_TOKEN=${MOQO_API_TOKEN:?missing/empty}
     restart: unless-stopped
 
   lamassu:


### PR DESCRIPTION
Adds MOQO_API_TOKEN to required x2gbfs env variables.
