### PR TITLE
fix-parkapi-image

### DIFF
--- a/.env
+++ b/.env
@@ -104,7 +104,7 @@ PARK_API_POSTGRES_USER=park-api
 PARK_API_POSTGRES_DB=park-api
 PARK_API_POSTGRES_HOST=park-api-db
 PARK_API_CELERY_BROKER_URL=amqp://park-api-rabbitmq
-PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:latest
+PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:20240402t183457
 PARK_API_DB_IMAGE=postgis/postgis:15-3.4-alpine
 
 # Caddy


### PR DESCRIPTION
In order to get to ParkAPI releases, we fix the version for a first time.