### PR TITLE
Geoserver/gtfs-api: only cast route_type explicitly

### DIFF
--- a/etc/gtfs/sql.d/21-route-type-to-int.sql
+++ b/etc/gtfs/sql.d/21-route-type-to-int.sql
@@ -1,2 +1,4 @@
--- Tell PostgreSQL that it can implicitly convert a route_type_val (e.g. `3`) to an integer just like it would convert a string `'3'`.
-CREATE CAST (api.route_type_val AS integer) WITH INOUT AS IMPLICIT;
+-- Tell PostgreSQL that it can explicitly convert a route_type_val (e.g. `3`) to an integer just like it would convert a string `'3'`.
+-- see also https://www.postgresql.org/docs/current/sql-createcast.html
+-- see also https://stackoverflow.com/a/56746056/1072129
+CREATE CAST (api.route_type_val AS integer) WITH INOUT AS ASSIGNMENT;

--- a/etc/gtfs/sql.d/31-geoserver-stations.sql
+++ b/etc/gtfs/sql.d/31-geoserver-stations.sql
@@ -28,7 +28,12 @@ CREATE MATERIALIZED VIEW geoserver.stations_with_served_routes AS
 				ST_Collect(array_agg(stop_loc::geometry)) AS stop_locs, -- todo: distinct by stop_id?,
 				route_type,
 				-- todo: in case the feed uses extended route_types, these need to be handled here also
-				case when route_type=0 then '20000' when route_type=2 then '10002' when route_type between 3 and 9 then '3000'||route_type else '9000'||route_type end prio_encoded_route_type,
+				case
+					when route_type::int = 0 then '20000'
+					when route_type::int = 2 then '10002'
+					when route_type::int between 3 and 9 then '3000' || route_type::int
+					else '9000' || route_type::int
+				end prio_encoded_route_type,
 				array_agg(DISTINCT route_name) AS route_names
 			FROM (
 				SELECT DISTINCT ON (stop_id, route_id)

--- a/etc/gtfs/sql.d/32-geoserver-shapes.sql
+++ b/etc/gtfs/sql.d/32-geoserver-shapes.sql
@@ -22,7 +22,7 @@ CREATE MATERIALIZED VIEW geoserver.shapes_with_routes AS
 -- allow filtering via Geoserver's CQL
 -- todo: solve properly in gtfs-via-postgres, for all enums
 DROP CAST IF EXISTS (api.route_type_val AS text);
-CREATE CAST (api.route_type_val AS text) WITH INOUT AS IMPLICIT;
+CREATE CAST (api.route_type_val AS text) WITH INOUT AS ASSIGNMENT;
 
 -- todo: primary/unique key?
 CREATE INDEX shapes_with_routes_shape_idx


### PR DESCRIPTION
This *might be* a breaking change, because we remove the ability to implicitly cast `route_type_val` to `integer`.

I checked the use case documented in #113 and `gtfs-api`'s filtering (using `curl 'http://localhost:4000/routes?route_type=eq.3&limit=1' -H 'Accept: application/json' -fsSL`), and both seem to work fine. @hbruch Can you think of more cases and queries which this change may break?

---

fixes https://github.com/mobidata-bw/ipl-orchestration/issues/113