### PR TITLE
added a new style for MobiData-BW:radvis_cycle_network

### DIFF
--- a/etc/geoserver/workspaces/MobiData-BW/ipl-db/radvis_cycle_network/layer.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/ipl-db/radvis_cycle_network/layer.xml
@@ -5,6 +5,11 @@
   <defaultStyle>
     <id>StyleInfoImpl--4537d375:18dec89cdf2:-452b</id>
   </defaultStyle>
+  <styles class="linked-hash-set">
+    <style>
+      <id>StyleInfoImpl--416e1479:18ec24680f0:-156f</id>
+    </style>
+  </styles>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl-16b18166:18b6756af37:-7adc</id>
   </resource>
@@ -13,5 +18,5 @@
     <logoHeight>0</logoHeight>
   </attribution>
   <dateCreated>2023-10-25 15:39:36.504 UTC</dateCreated>
-  <dateModified>2024-02-27 22:07:45.949 UTC</dateModified>
+  <dateModified>2024-04-09 11:20:28.557 UTC</dateModified>
 </layer>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_radvis_cn_all.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_radvis_cn_all.sld
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>RadVIS Radnetze Baden-Württemberg</Name>
+    <UserStyle>
+      <FeatureTypeStyle>
+        <Rule>
+          <Name>Kommunales Netz</Name>
+          <Title>Kommunales Netz</Title>
+          <ogc:Filter>
+            <ogc:And>
+              <ogc:And>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>ext_bw_kommunetz</ogc:PropertyName>
+                  <ogc:Literal>1</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+                <ogc:Not>
+                  <ogc:PropertyIsEqualTo>
+                    <ogc:PropertyName>ext_bw_kreisnetz</ogc:PropertyName>
+                    <ogc:Literal>1</ogc:Literal>
+                  </ogc:PropertyIsEqualTo>
+                </ogc:Not>
+              </ogc:And>
+              <ogc:Not>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>ext_bw_landesnetz</ogc:PropertyName>
+                  <ogc:Literal>1</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+              </ogc:Not>
+            </ogc:And>
+          </ogc:Filter>
+          <!--<MaxScaleDenominator>100000</MaxScaleDenominator>-->
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#0020aa</CssParameter>
+              <CssParameter name="stroke-width">2</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+        <Rule>
+          <Name>Kreisnetz</Name>
+          <Title>Kreisnetzz</Title>
+          <ogc:Filter>
+            <ogc:And>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>ext_bw_kreisnetz</ogc:PropertyName>
+                <ogc:Literal>1</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+              <ogc:Not>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>ext_bw_landesnetz</ogc:PropertyName>
+                  <ogc:Literal>1</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+              </ogc:Not>
+            </ogc:And>
+          </ogc:Filter>
+          <!--<MaxScaleDenominator>200000</MaxScaleDenominator>-->
+ <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#008001</CssParameter>
+              <CssParameter name="stroke-width">2</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+        <Rule>
+          <Name>RadNETZ-BW</Name>
+          <Title>RadNETZ-BW</Title>
+          <ogc:Filter>
+            <ogc:PropertyIsEqualTo>
+              <ogc:PropertyName>ext_bw_landesnetz</ogc:PropertyName>
+              <ogc:Literal>1</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#FF7F00</CssParameter>
+              <CssParameter name="stroke-width">3</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>
+

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_radvis_cn_all.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_radvis_cn_all.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>RadVIS Radnetze Baden-Württemberg</Name>
+    <UserStyle>
+      <FeatureTypeStyle>
+        <Rule>
+          <Name>Kommunales Netz</Name>
+          <Title>Kommunales Netz</Title>
+          <ogc:Filter>
+            <ogc:And>
+              <ogc:And>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>ext_bw_kommunetz</ogc:PropertyName>
+                  <ogc:Literal>1</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+                <ogc:Not>
+                  <ogc:PropertyIsEqualTo>
+                    <ogc:PropertyName>ext_bw_kreisnetz</ogc:PropertyName>
+                    <ogc:Literal>1</ogc:Literal>
+                  </ogc:PropertyIsEqualTo>
+                </ogc:Not>
+              </ogc:And>
+              <ogc:Not>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>ext_bw_landesnetz</ogc:PropertyName>
+                  <ogc:Literal>1</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+              </ogc:Not>
+            </ogc:And>
+          </ogc:Filter>
+          <MaxScaleDenominator>100000</MaxScaleDenominator>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#0020aa</CssParameter>
+              <CssParameter name="stroke-width">2</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+        <Rule>
+          <Name>Kreisnetz</Name>
+          <Title>Kreisnetzz</Title>
+          <ogc:Filter>
+            <ogc:And>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>ext_bw_kreisnetz</ogc:PropertyName>
+                <ogc:Literal>1</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+              <ogc:Not>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>ext_bw_landesnetz</ogc:PropertyName>
+                  <ogc:Literal>1</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+              </ogc:Not>
+            </ogc:And>
+          </ogc:Filter>
+          <MaxScaleDenominator>200000</MaxScaleDenominator>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#008001</CssParameter>
+              <CssParameter name="stroke-width">2</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+        <Rule>
+          <Name>RadNETZ-BW</Name>
+          <Title>RadNETZ-BW</Title>
+          <ogc:Filter>
+            <ogc:PropertyIsEqualTo>
+              <ogc:PropertyName>ext_bw_landesnetz</ogc:PropertyName>
+              <ogc:Literal>1</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#FF7F00</CssParameter>
+              <CssParameter name="stroke-width">3</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
I added a style for the cycle network that removes the `MaxScaleDenominator` that only visualized some some layers on a higher zoom level. This new style is an addition to the default style which still takes the zoom level into account
 