### PR TITLE
Geoserver: SLD and typo fixes

### DIFF
--- a/etc/geoserver/workspaces/MobiData-BW/ipl-db/sharing_stations_cargo_bicycle/featuretype.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/ipl-db/sharing_stations_cargo_bicycle/featuretype.xml
@@ -5,7 +5,7 @@
   <namespace>
     <id>NamespaceInfoImpl--48f676ef:18997a59df5:-7ff5</id>
   </namespace>
-  <title>Lasterad-Leihstationen</title>
+  <title>Lastenrad-Leihstationen</title>
   <keywords>
     <string>features</string>
     <string>cargo_bicycle_sharing_station</string>

--- a/etc/geoserver/workspaces/MobiData-BW/ipl-db/sharing_stations_cargo_bicycle/layer.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/ipl-db/sharing_stations_cargo_bicycle/layer.xml
@@ -1,5 +1,5 @@
 <layer>
-  <name>cargo_bicycle_sharing_stationa</name>
+  <name>cargo_bicycle_sharing_station</name>
   <id>LayerInfoImpl--d3e2e11:18c35d543f4:-7ff5</id>
   <type>VECTOR</type>
   <defaultStyle>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_radvis_cn_default.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_radvis_cn_default.sld
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd">
   <NamedLayer>
     <Name>RadVIS Radnetze Baden-Württemberg</Name>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_radvis_cn_default.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_radvis_cn_default.sld
@@ -39,7 +39,7 @@
         </Rule>
         <Rule>
           <Name>Kreisnetz</Name>
-          <Title>Kreisnetzz</Title>
+          <Title>Kreisnetz</Title>
           <ogc:Filter>
             <ogc:And>
               <ogc:PropertyIsEqualTo>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_stations_by_operator.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_stations_by_operator.sld
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <StyledLayerDescriptor version="1.0.0"
   xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd"
   xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc"

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_stations_default.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_stations_default.sld
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <StyledLayerDescriptor version="1.0.0"
   xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd"
   xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc"

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_vehicles_by_operator.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_vehicles_by_operator.sld
@@ -7,7 +7,7 @@
   <NamedLayer>
     <Name>mdbw_sharing_vehicles_by_operator</Name>
     <UserStyle>
-      <Title>MobiData-BW Sharing-Farzeuge nach Anbieter</Title>
+      <Title>MobiData-BW Free-Floating-Fahrzeuge nach Anbieter</Title>
       <FeatureTypeStyle>
         <Rule>
           <Title>Nextbike</Title>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_vehicles_by_operator.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_vehicles_by_operator.sld
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <StyledLayerDescriptor version="1.0.0"
   xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd"
   xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc"

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_vehicles_default.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_vehicles_default.sld
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <StyledLayerDescriptor version="1.0.0"
   xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd"
   xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc"

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_vehicles_default.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_vehicles_default.sld
@@ -5,12 +5,12 @@
   xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <NamedLayer>
-    <Name>mdbw_sharing_default</Name>
+    <Name>mdbw_sharing_vehicles_default</Name>
     <UserStyle>
-      <Title>MobiData-BW Sharing-Stationen</Title>
+      <Title>MobiData-BW Free-Floating-Fahrzeuge</Title>
       <FeatureTypeStyle>
         <Rule>
-          <Title>Nextbike</Title>
+          <Title>Free-Floating-Fahrzeuge</Title>
           <PointSymbolizer>
             <Graphic>
               <Mark>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_traffic_roadworks_default.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_traffic_roadworks_default.sld
@@ -7,6 +7,7 @@
       <Abstract></Abstract>
       <FeatureTypeStyle>
         <Rule>
+          <Title>Beide Fahrtrichtungen betroffen</Title>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>direction</ogc:PropertyName>
@@ -29,6 +30,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
+          <Title>Eine Fahrtrichtung betroffen</Title>
           <ogc:Filter>
             <ogc:Not>
               <ogc:PropertyIsEqualTo>
@@ -55,7 +57,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <!-- Einseitige Sperrungen Smybol -->
+          <Title>Einseitige Sperrung</Title>
           <ogc:Filter>
             <ogc:And>
               <ogc:Not>
@@ -104,7 +106,7 @@
           </PointSymbolizer>
         </Rule>
         <Rule>
-          <!-- Einseitige Nicht-Sperrungen Smybol -->
+          <Title>Einseitige Beeinträchtigung</Title>
           <ogc:Filter>
             <ogc:And>
               <ogc:Not>
@@ -155,7 +157,7 @@
           </PointSymbolizer>
         </Rule>
         <Rule>
-          <!-- Beidseitige Sperrungen Smybol -->
+          <Title>Vollsperrung</Title>
           <ogc:Filter>
             <ogc:And>
               <ogc:PropertyIsEqualTo>
@@ -202,7 +204,7 @@
           </PointSymbolizer>
         </Rule>
         <Rule>
-          <!-- Beidseitige Nicht-Sperrungen Smybol -->
+          <Title>Beeinträchtigung beider Fahrtrichtungen</Title>
           <ogc:Filter>
             <ogc:And>
               <ogc:PropertyIsEqualTo>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_traffic_roadworks_default.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_traffic_roadworks_default.sld
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd">
   <NamedLayer>
     <Name>Arbeitsstellen</Name>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_transit_stations_default.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_transit_stations_default.sld
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <StyledLayerDescriptor version="1.0.0"
   xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd"
   xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc"

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_transit_stops_default.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_transit_stops_default.sld
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
   <NamedLayer>
     <Name>mdbw_transit_stops_default</Name>


### PR DESCRIPTION
This PR 
* fixes some typos in layer and sld titles
* fixes sld encoding issues (encoding was declared as iso-8859-1, but is utf-8)
* adds titles to roadwork sld

Note that for single rule the rule title will not be displayed per default. If you want it to render, you need to enforce this via `LEGEND_OPTIONS`, i.e. [LEGEND_OPTIONS=forceLabels:on](https://api.mobidata-bw.de/geoserver/wms?REQUEST=GetLegendGraphic&VERSION=1.0.0&FORMAT=image/png&WIDTH=20&HEIGHT=20&LAYER=MobiData-BW:sharing_vehicles&LEGEND_OPTIONS=forceLabels:on)

Fixes #124 and fixes #117