### PR TITLE
Geoserver: parking sites layer: change style names, point size and some colors

### DIFF
--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_parking_sites_default.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_parking_sites_default.sld
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ogc="http://www.opengis.net/ogc" version="1.1.0" xmlns:se="http://www.opengis.net/se" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <NamedLayer>
+    <se:Name>parking_site</se:Name>
+    <UserStyle>
+      <se:Name>parking_site</se:Name>
+      <se:FeatureTypeStyle>
+        <se:Rule>
+          <se:Name>Geschlossen</se:Name>
+          <se:Description>
+            <se:Title>Geschlossen</se:Title>
+          </se:Description>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:PropertyIsEqualTo>
+              <ogc:PropertyName>realtime_opening_status</ogc:PropertyName>
+              <ogc:Literal>CLOSED</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#ed0000</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke/>
+              </se:Mark>
+              <se:Size>10</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <se:Name>Keine Echtzeitdaten</se:Name>
+          <se:Description>
+            <se:Title>Keine Echtzeitdaten</se:Title>
+          </se:Description>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:PropertyIsNull>
+              <ogc:PropertyName>realtime_free_capacity</ogc:PropertyName>
+            </ogc:PropertyIsNull>
+          </ogc:Filter>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#615fdf</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke/>
+              </se:Mark>
+              <se:Size>10</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <se:Name>Parkplätze verfügbar</se:Name>
+          <se:Description>
+            <se:Title>Parkplätze verfügbar</se:Title>
+          </se:Description>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:And>
+              <ogc:PropertyIsGreaterThanOrEqualTo>
+                <ogc:Div>
+                  <ogc:Mul>
+                    <ogc:PropertyName>realtime_free_capacity</ogc:PropertyName>
+                    <ogc:Literal>1</ogc:Literal>
+                  </ogc:Mul>
+                  <ogc:Function name="if_then_else">
+                    <ogc:Function name="isNull">
+                      <ogc:PropertyName>realtime_capacity</ogc:PropertyName>
+                    </ogc:Function>
+                    <ogc:PropertyName>capacity</ogc:PropertyName>
+                    <ogc:PropertyName>realtime_capacity</ogc:PropertyName>
+                  </ogc:Function>
+                </ogc:Div>
+                <ogc:Literal>0.2</ogc:Literal>
+              </ogc:PropertyIsGreaterThanOrEqualTo>
+              <ogc:PropertyIsNotEqualTo>
+                <ogc:PropertyName>realtime_opening_status</ogc:PropertyName>
+                <ogc:Literal>CLOSED</ogc:Literal>
+              </ogc:PropertyIsNotEqualTo>
+            </ogc:And>
+          </ogc:Filter>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#059b02</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke/>
+              </se:Mark>
+              <se:Size>10</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <se:Name>Wenige Parkplätze verfügbar</se:Name>
+          <se:Description>
+            <se:Title>Wenige Parkplätze verfügbar</se:Title>
+          </se:Description>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:And>
+              <ogc:PropertyIsBetween>
+                <ogc:Div>
+                  <ogc:Mul>
+                    <ogc:PropertyName>realtime_free_capacity</ogc:PropertyName>
+                    <ogc:Literal>1</ogc:Literal>
+                  </ogc:Mul>
+                  <ogc:Function name="if_then_else">
+                    <ogc:Function name="isNull">
+                      <ogc:PropertyName>realtime_capacity</ogc:PropertyName>
+                    </ogc:Function>
+                    <ogc:PropertyName>capacity</ogc:PropertyName>
+                    <ogc:PropertyName>realtime_capacity</ogc:PropertyName>
+                  </ogc:Function>
+                </ogc:Div>
+                <ogc:LowerBoundary>
+                  <ogc:Literal>0.02</ogc:Literal>
+                </ogc:LowerBoundary>
+                <ogc:UpperBoundary>
+                  <ogc:Literal>0.2</ogc:Literal>
+                </ogc:UpperBoundary>        
+              </ogc:PropertyIsBetween>
+              <ogc:PropertyIsNotEqualTo>
+                <ogc:PropertyName>realtime_opening_status</ogc:PropertyName>
+                <ogc:Literal>CLOSED</ogc:Literal>
+              </ogc:PropertyIsNotEqualTo>
+            </ogc:And>
+          </ogc:Filter>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#dfab27</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke/>
+              </se:Mark>
+              <se:Size>10</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+        <se:Rule>
+          <se:Name>Keine oder sehr wenige Parkplätze verfügbar</se:Name>
+          <se:Description>
+            <se:Title>Keine oder sehr wenige Parkplätze verfügbar</se:Title>
+          </se:Description>
+          <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:And>
+              <ogc:PropertyIsGreaterThanOrEqualTo>
+                <ogc:PropertyName>realtime_free_capacity</ogc:PropertyName>
+                <ogc:Literal>0</ogc:Literal>
+              </ogc:PropertyIsGreaterThanOrEqualTo>
+              <ogc:PropertyIsLessThanOrEqualTo>
+                <ogc:Div>
+                  <ogc:Mul>
+                    <ogc:PropertyName>realtime_free_capacity</ogc:PropertyName>
+                    <ogc:Literal>1</ogc:Literal>
+                  </ogc:Mul>
+                  <ogc:Function name="if_then_else">
+                    <ogc:Function name="isNull">
+                      <ogc:PropertyName>realtime_capacity</ogc:PropertyName>
+                    </ogc:Function>
+                    <ogc:PropertyName>capacity</ogc:PropertyName>
+                    <ogc:PropertyName>realtime_capacity</ogc:PropertyName>
+                  </ogc:Function>
+                </ogc:Div>
+                <ogc:Literal>0.02</ogc:Literal>
+              </ogc:PropertyIsLessThanOrEqualTo>
+              <ogc:PropertyIsNotEqualTo>
+                <ogc:PropertyName>realtime_opening_status</ogc:PropertyName>
+                <ogc:Literal>CLOSED</ogc:Literal>
+              </ogc:PropertyIsNotEqualTo>
+            </ogc:And>
+          </ogc:Filter>
+          <se:PointSymbolizer>
+            <se:Graphic>
+              <se:Mark>
+                <se:WellKnownName>circle</se:WellKnownName>
+                <se:Fill>
+                  <se:SvgParameter name="fill">#ed0000</se:SvgParameter>
+                </se:Fill>
+                <se:Stroke/>
+              </se:Mark>
+              <se:Size>10</se:Size>
+            </se:Graphic>
+          </se:PointSymbolizer>
+        </se:Rule>
+      </se:FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_parking_sites_default.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_parking_sites_default.xml
@@ -1,0 +1,14 @@
+<style>
+  <id>StyleInfoImpl--3cb38bb4:18bc8a9af4b:-7ffb</id>
+  <name>mdbw_parking_sites_default</name>
+  <workspace>
+    <id>WorkspaceInfoImpl--48f676ef:18997a59df5:-7ff6</id>
+  </workspace>
+  <format>sld</format>
+  <languageVersion>
+    <version>1.1.0</version>
+  </languageVersion>
+  <filename>mdbw_parking_sites_default.sld</filename>
+  <dateCreated>2023-11-13 13:06:48.287 UTC</dateCreated>
+  <dateModified>2024-04-10 12:55:34.141 UTC</dateModified>
+</style>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_parking_sites_types.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_parking_sites_types.sld
@@ -9,7 +9,7 @@
     <UserStyle>
       <Title>MobiData-BW Parkhäuser und -plätze</Title>
       <FeatureTypeStyle>
-      <Rule>
+        <Rule>
           <Title>Parkhaus</Title>
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
@@ -29,12 +29,12 @@
                   <CssParameter name="stroke-width">0.5</CssParameter>
                 </Stroke>
               </Mark>
-              <Size>6</Size>
+              <Size>10</Size>
             </Graphic>
           </PointSymbolizer>
         </Rule>
         <Rule>        
-            <Title>Tiefgarage</Title>         
+          <Title>Tiefgarage</Title>         
           <ogc:Filter>
             <ogc:PropertyIsEqualTo>
               <ogc:PropertyName>type</ogc:PropertyName>
@@ -53,7 +53,7 @@
                   <CssParameter name="stroke-width">0.5</CssParameter>
                 </Stroke>
               </Mark>
-              <Size>6</Size>
+              <Size>10</Size>
             </Graphic>
           </PointSymbolizer>
         </Rule>
@@ -101,7 +101,7 @@
                   <CssParameter name="stroke-width">0.5</CssParameter>
                 </Stroke>
               </Mark>
-              <Size>6</Size>
+              <Size>10</Size>
             </Graphic>
           </PointSymbolizer>
         </Rule>
@@ -120,7 +120,7 @@
                   <CssParameter name="stroke-width">0.5</CssParameter>
                 </Stroke>
               </Mark>
-              <Size>6</Size>
+              <Size>10</Size>
             </Graphic>
           </PointSymbolizer>
         </Rule>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_parking_sites_types.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_parking_sites_types.xml
@@ -10,5 +10,5 @@
   </languageVersion>
   <filename>mdbw_parking_sites_types.sld</filename>
   <dateCreated>2023-11-13 12:01:49.764 UTC</dateCreated>
-  <dateModified>2024-03-13 13:17:44.285 UTC</dateModified>
+  <dateModified>2024-04-10 12:55:39.844 UTC</dateModified>
 </style>


### PR DESCRIPTION
## Changes
- Renaming of sld from `parking_site_default` to `parking_sites_default`
- Increase of point size to 10
- Lighter blue for no realtime data layer of style `parking_site_default`

---

follow-up of #119, #123, #125 & #129