### PR TITLE
major park-api upgrade

### DIFF
--- a/.env
+++ b/.env
@@ -104,7 +104,7 @@ PARK_API_POSTGRES_USER=park-api
 PARK_API_POSTGRES_DB=park-api
 PARK_API_POSTGRES_HOST=park-api-db
 PARK_API_CELERY_BROKER_URL=amqp://park-api-rabbitmq
-PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.1.1
+PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.2.0
 PARK_API_DB_IMAGE=postgis/postgis:15-3.4-alpine
 
 # Caddy

--- a/.env
+++ b/.env
@@ -104,7 +104,7 @@ PARK_API_POSTGRES_USER=park-api
 PARK_API_POSTGRES_DB=park-api
 PARK_API_POSTGRES_HOST=park-api-db
 PARK_API_CELERY_BROKER_URL=amqp://park-api-rabbitmq
-PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:20240402t183457
+PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.1.1
 PARK_API_DB_IMAGE=postgis/postgis:15-3.4-alpine
 
 # Caddy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
--
+- Added bike parking support in ParkAPI: https://github.com/ParkenDD/park-api-v3/pull/106 . Includes database migration
+  and more fields in public API: https://api.mobidata-bw.de/park-api/documentation/public.html#/paths/v3-parking-sites/get
+- Added new ParkAPI sources:
+  - Barrierefreie Reisekette Baden-Württemberg: PKW-Parkplätze an Bahnhöfen
+  - Barrierefreie Reisekette Baden-Württemberg: PKW-Parkplätze an Bushaltestellen
+  - Barrierefreie Reisekette Baden-Württemberg: Fahrrad-Parkplätze an Bahnhöfen
+  - Barrierefreie Reisekette Baden-Württemberg: Fahrrad-Parkplätze an Bushaltestellen
 
 ### Changed
 
--
+- Fixed ParkAPI v1 endpoint to match old API specs: https://github.com/ParkenDD/park-api-v3/pull/127
+- Changed to ParkAPI module approach: https://github.com/ParkenDD/park-api-v3/pull/106 . Published at
+  https://pypi.org/project/parkapi-sources/
+- Changed config file layout at ParkAPI, now all sources are defined in the same place. Example config:
+  https://github.com/ParkenDD/park-api-v3/blob/75a87ffe6edd3eece57a4b73692f01b6695c74e0/config_dist_dev.yaml
 
 ### Removed
 
@@ -23,7 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- Add a CHANGELOG to document changes 
+- Add a CHANGELOG to document changes
 - Add new GBFS feeds stadtmobil_karlsruhe (https://github.com/mobidata-bw/ipl-orchestration/pull/139) and nextbike_kk (https://github.com/mobidata-bw/ipl-orchestration/pull/140) (includes x2gbfs upgrade to 2024-04-30t05-08)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Added bike parking support in ParkAPI: https://github.com/ParkenDD/park-api-v3/pull/106 . Includes database migration
   and more fields in public API: https://api.mobidata-bw.de/park-api/documentation/public.html#/paths/v3-parking-sites/get
+- [Normalizes radius search at ParkAPI](https://github.com/ParkenDD/park-api-v3/pull/133)
 - Added new ParkAPI sources:
   - Barrierefreie Reisekette Baden-Württemberg: PKW-Parkplätze an Bahnhöfen
   - Barrierefreie Reisekette Baden-Württemberg: PKW-Parkplätze an Bushaltestellen
   - Barrierefreie Reisekette Baden-Württemberg: Fahrrad-Parkplätze an Bahnhöfen
   - Barrierefreie Reisekette Baden-Württemberg: Fahrrad-Parkplätze an Bushaltestellen
+  - Stadt Neckarsulm: Fahrrad-Abstellanlagen
+  - Kienzler
+  - Stadt Mannheim
+  - Stadt Buchen
+  - Stadt Reutlingen: Fahrrad-Abstellanlagen
+  - Baden-Württemberg: Parken und Mitfahren
 
 ### Changed
 
@@ -24,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   https://pypi.org/project/parkapi-sources/
 - Changed config file layout at ParkAPI, now all sources are defined in the same place. Example config:
   https://github.com/ParkenDD/park-api-v3/blob/75a87ffe6edd3eece57a4b73692f01b6695c74e0/config_dist_dev.yaml
+- Fixes OpenAPI response schema at generic parking site endpoints
 
 ### Removed
 

--- a/etc/park-api/config.yaml
+++ b/etc/park-api/config.yaml
@@ -1,15 +1,3 @@
-PARK_API_CONVERTER:
-  - ulm
-  - freiburg
-  - heidelberg
-  # Disable Heilbronn as long as legal status is unclear
-  # - heilbronn
-  # Karlsruhe currently fails, see https://github.com/ParkenDD/ParkAPI2-sources/issues/40
-  # - karlsruhe
-  - mannheim
-  - bahn_v2
-  - pbw
-
 OPENAPI_CONTACT_MAIL: 'mobidatabw-technik@nvbw.de'
 OPENAPI_TOS: 'https://www.mobidata-bw.de/pages/nutzungsbedingungen'
 OPENAPI_SERVERS:


### PR DESCRIPTION
Major park-api update. Requires https://github.com/mobidata-bw/ipl-ansible/pull/46 to be merged / used during deployment.