### PR TITLE
Pin docker image versions

### DIFF
--- a/.env
+++ b/.env
@@ -7,10 +7,10 @@ DOCKER_LOCAL_USER=1000:1000
 # https://en.wikipedia.org/wiki/Tz_database
 TZ=Europe/Berlin
 
-TRANSFORMER_PROXY_IMAGE=ghcr.io/mobidata-bw/ipl-proxy:latest
+TRANSFORMER_PROXY_IMAGE=ghcr.io/mobidata-bw/ipl-proxy:2024-04-23T16-02
 TRANSFORMER_PROXY_PORT=8400
 
-LAMASSU_IMAGE=entur/lamassu:latest
+LAMASSU_IMAGE=entur/lamassu:2024-04-22T18-58
 LAMASSU_PORT=8500
 LAMASSU_ADMIN_PORT=9002
 LAMASSU_BASE_URL=http://localhost:8080/sharing
@@ -27,7 +27,7 @@ IPL_POSTGRES_DB=geoserver
 IPL_POSTGRES_USER=geoserver
 
 # x2gbfs variables
-X2GBFS_IMAGE=ghcr.io/mobidata-bw/x2gbfs:latest
+X2GBFS_IMAGE=ghcr.io/mobidata-bw/x2gbfs:2024-04-22T11-45
 X2GBFS_PROVIDERS=deer,voi-raumobil,lastenvelo_fr,stadtmobil_stuttgart,stadtmobil_karlsruhe,stadtmobil_suedbaden,my-e-car,stadtwerk_tauberfranken
 X2GBFS_UPDATE_INTERVAL_SECONDS=60
 


### PR DESCRIPTION
This PR pins the docker image versions for `lamassu`, `ipl-transformer-proxy`and `x2gbfs`.

Note: the `ocpdb` image is still at `latest`. @the-infinity will you introduce image tags near-term, then we could fix it as well.