### PR TITLE
Bump x2gbfs version

### DIFF
--- a/.env
+++ b/.env
@@ -26,8 +26,8 @@ IPL_POSTGRES_PORT=5432
 IPL_POSTGRES_DB=geoserver
 IPL_POSTGRES_USER=geoserver
 
-# x2gbfs variables
-X2GBFS_IMAGE=ghcr.io/mobidata-bw/x2gbfs:2024-04-22T11-45
+# x2gbfs variables (Note: when changing the providers, be sure to check if the image version supports them)
+X2GBFS_IMAGE=ghcr.io/mobidata-bw/x2gbfs:2024-04-30t05-08
 X2GBFS_PROVIDERS=deer,voi-raumobil,lastenvelo_fr,stadtmobil_stuttgart,stadtmobil_karlsruhe,stadtmobil_suedbaden,my-e-car,stadtwerk_tauberfranken
 X2GBFS_UPDATE_INTERVAL_SECONDS=60
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 
-## [Unreleased, planned for 2024-04-30]
+## [Unreleased, planned for 2024-05-07]
 
 ### Added
 
-- Add LAMASSU_FEED_UPATE_INTERVAL_IN_MS parameter, which defaults to 6h. For prod environments, set to e.g. 1 min (= 60000).
-- Add a CHANGELOG to document changes
+-
 
 ### Changed
 
+-
 
 ### Removed
 
+-
+
+## [2024-04-30]
+
+### Added
+
+- Add a CHANGELOG to document changes 
+- Add new GBFS feeds stadtmobil_karlsruhe (https://github.com/mobidata-bw/ipl-orchestration/pull/139) and nextbike_kk (https://github.com/mobidata-bw/ipl-orchestration/pull/140) (includes x2gbfs upgrade to 2024-04-30t05-08)
+
+### Changed
+
+- Changed gbfs feed update interval from 30s to 60s (60000ms) for prod, 6h for other machines. This can be configured via the new LAMASSU_FEED_UPATE_INTERVAL_IN_MS parameter, which defaults to 6h.
+- Fix: For provider deer, inactive bookings are now ignored when calculating `is_reserved` status (https://github.com/mobidata-bw/x2gbfs/pull/95)
+- Minor WMS styling changes (https://github.com/mobidata-bw/ipl-orchestration/pull/135)


### PR DESCRIPTION
This PR bumps x2gbfs version to `2024-04-30t05-08` which includes new `stadtmobil_karlsruhe` feed and summarizes changes for ipl release `2024-04-30`.