### PR TITLE
added new style for roadworks layer and set it as default

### DIFF
--- a/etc/geoserver/workspaces/MobiData-BW/ipl-db/roadworks/layer.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/ipl-db/roadworks/layer.xml
@@ -5,6 +5,11 @@
   <defaultStyle>
     <id>StyleInfoImpl--2f417ac5:18e2df033ce:-7e89</id>
   </defaultStyle>
+  <styles class="linked-hash-set">
+    <style>
+      <id>StyleInfoImpl--476372f4:18f3cd976b2:-7fd4</id>
+    </style>
+  </styles>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--2f417ac5:18e2df033ce:-7ff1</id>
   </resource>
@@ -13,5 +18,5 @@
     <logoHeight>0</logoHeight>
   </attribution>
   <dateCreated>2024-03-11 14:39:41.522 UTC</dateCreated>
-  <dateModified>2024-03-11 14:50:34.854 UTC</dateModified>
+  <dateModified>2024-05-03 12:18:40.810 UTC</dateModified>
 </layer>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_traffic_roadworks_default.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_traffic_roadworks_default.sld
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd">
   <NamedLayer>
-    <Name>Arbeitsstellen</Name>
+    <Name>mdbw_traffic_roadworks_default</Name>
     <UserStyle>
       <Title>Arbeitsstelle</Title>
       <Abstract></Abstract>
@@ -57,168 +57,7 @@
           </LineSymbolizer>
         </Rule>
         <Rule>
-          <Title>Einseitige Sperrung</Title>
-          <ogc:Filter>
-            <ogc:And>
-              <ogc:Not>
-                <ogc:PropertyIsEqualTo>
-                  <ogc:PropertyName>direction</ogc:PropertyName>
-                  <ogc:Literal>BOTH_DIRECTIONS</ogc:Literal>
-                </ogc:PropertyIsEqualTo>
-              </ogc:Not>
-              <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>type</ogc:PropertyName>
-                <ogc:Literal>ROAD_CLOSED</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-            </ogc:And>
-          </ogc:Filter>
-          <PointSymbolizer>
-            <Geometry>
-              <ogc:Function name="startPoint">
-                <ogc:PropertyName>geometry</ogc:PropertyName>
-              </ogc:Function>
-            </Geometry>
-            <Graphic>
-              <Mark>
-                <WellKnownName>circle</WellKnownName>
-                <Fill>
-                  <CssParameter name="fill">#A93030</CssParameter>
-                </Fill>
-              </Mark>
-              <Size>8</Size>
-            </Graphic>
-          </PointSymbolizer>
-          <PointSymbolizer>
-            <Geometry>
-              <ogc:Function name="startPoint">
-                <ogc:PropertyName>geometry</ogc:PropertyName>
-              </ogc:Function>
-            </Geometry>
-            <Graphic>
-              <Mark>
-                <WellKnownName>circle</WellKnownName>
-                <Fill>
-                  <CssParameter name="fill">#ffffff</CssParameter>
-                </Fill>
-              </Mark>
-              <Size>5</Size>
-            </Graphic>
-          </PointSymbolizer>
-        </Rule>
-        <Rule>
-          <Title>Einseitige Beeinträchtigung</Title>
-          <ogc:Filter>
-            <ogc:And>
-              <ogc:Not>
-                <ogc:PropertyIsEqualTo>
-                  <ogc:PropertyName>direction</ogc:PropertyName>
-                  <ogc:Literal>BOTH_DIRECTIONS</ogc:Literal>
-                </ogc:PropertyIsEqualTo>
-              </ogc:Not>
-              <ogc:Not>
-                <ogc:PropertyIsEqualTo>
-                  <ogc:PropertyName>type</ogc:PropertyName>
-                  <ogc:Literal>ROAD_CLOSED</ogc:Literal>
-                </ogc:PropertyIsEqualTo>
-              </ogc:Not>
-            </ogc:And>
-          </ogc:Filter>
-          <PointSymbolizer>
-            <Geometry>
-              <ogc:Function name="startPoint">
-                <ogc:PropertyName>geometry</ogc:PropertyName>
-              </ogc:Function>
-            </Geometry>
-            <Graphic>
-              <Mark>
-                <WellKnownName>triangle</WellKnownName>
-                <Fill>
-                  <CssParameter name="fill">#A93030</CssParameter>
-                </Fill>
-              </Mark>
-              <Size>8</Size>
-            </Graphic>
-          </PointSymbolizer>
-          <PointSymbolizer>
-            <Geometry>
-              <ogc:Function name="startPoint">
-                <ogc:PropertyName>geometry</ogc:PropertyName>
-              </ogc:Function>
-            </Geometry>
-            <Graphic>
-              <Mark>
-                <WellKnownName>triangle</WellKnownName>
-                <Fill>
-                  <CssParameter name="fill">#ffffff</CssParameter>
-                </Fill>
-              </Mark>
-              <Size>3</Size>
-            </Graphic>
-          </PointSymbolizer>
-        </Rule>
-        <Rule>
-          <Title>Vollsperrung</Title>
-          <ogc:Filter>
-            <ogc:And>
-              <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>direction</ogc:PropertyName>
-                <ogc:Literal>BOTH_DIRECTIONS</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-              <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>type</ogc:PropertyName>
-                <ogc:Literal>ROAD_CLOSED</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-            </ogc:And>
-          </ogc:Filter>
-          <PointSymbolizer>
-            <Geometry>
-              <ogc:Function name="interiorPoint">
-                <ogc:PropertyName>geometry</ogc:PropertyName>
-              </ogc:Function>
-            </Geometry>
-            <Graphic>
-              <Mark>
-                <WellKnownName>circle</WellKnownName>
-                <Fill>
-                  <CssParameter name="fill">#A93030</CssParameter>
-                </Fill>
-              </Mark>
-              <Size>8</Size>
-            </Graphic>
-          </PointSymbolizer>
-          <PointSymbolizer>
-            <Geometry>
-              <ogc:Function name="interiorPoint">
-                <ogc:PropertyName>geometry</ogc:PropertyName>
-              </ogc:Function>
-            </Geometry>
-            <Graphic>
-              <Mark>
-                <WellKnownName>circle</WellKnownName>
-                <Fill>
-                  <CssParameter name="fill">#ffffff</CssParameter>
-                </Fill>
-              </Mark>
-              <Size>5</Size>
-            </Graphic>
-          </PointSymbolizer>
-        </Rule>
-        <Rule>
-          <Title>Beeinträchtigung beider Fahrtrichtungen</Title>
-          <ogc:Filter>
-            <ogc:And>
-              <ogc:PropertyIsEqualTo>
-                <ogc:PropertyName>direction</ogc:PropertyName>
-                <ogc:Literal>BOTH_DIRECTIONS</ogc:Literal>
-              </ogc:PropertyIsEqualTo>
-              <ogc:Not>
-                <ogc:PropertyIsEqualTo>
-                  <ogc:PropertyName>type</ogc:PropertyName>
-                  <ogc:Literal>ROAD_CLOSED</ogc:Literal>
-                </ogc:PropertyIsEqualTo>
-              </ogc:Not>
-            </ogc:And>
-          </ogc:Filter>
+          <Title>Arbeitsstellen</Title>
           <PointSymbolizer>
             <Geometry>
               <ogc:Function name="interiorPoint">
@@ -232,7 +71,7 @@
                   <CssParameter name="fill">#A93030</CssParameter>
                 </Fill>
               </Mark>
-              <Size>10</Size>
+              <Size>11</Size>
             </Graphic>
           </PointSymbolizer>
           <PointSymbolizer>
@@ -248,7 +87,7 @@
                   <CssParameter name="fill">#ffffff</CssParameter>
                 </Fill>
               </Mark>
-              <Size>8</Size>
+              <Size>9</Size>
             </Graphic>
           </PointSymbolizer>
         </Rule>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_traffic_roadworks_default.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_traffic_roadworks_default.xml
@@ -10,5 +10,5 @@
   </languageVersion>
   <filename>mdbw_traffic_roadworks_default.sld</filename>
   <dateCreated>2024-03-11 14:40:34.117 UTC</dateCreated>
-  <dateModified>2024-03-12 08:47:27.678 UTC</dateModified>
+  <dateModified>2024-05-03 12:16:29.664 UTC</dateModified>
 </style>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_traffic_roadworks_detailed.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_traffic_roadworks_detailed.sld
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>mdbw_traffic_roadworks_detailed</Name>
+    <UserStyle>
+      <Title>Arbeitsstelle</Title>
+      <Abstract></Abstract>
+      <FeatureTypeStyle>
+        <Rule>
+          <Title>Beide Fahrtrichtungen betroffen</Title>
+          <ogc:Filter>
+            <ogc:PropertyIsEqualTo>
+              <ogc:PropertyName>direction</ogc:PropertyName>
+              <ogc:Literal>BOTH_DIRECTIONS</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#ffffff</CssParameter>
+              <CssParameter name="stroke-width">5</CssParameter>
+              <CssParameter name="stroke-linecap">round</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#A93030</CssParameter>
+              <CssParameter name="stroke-width">3</CssParameter>
+              <CssParameter name="stroke-dasharray">4 2</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+        <Rule>
+          <Title>Eine Fahrtrichtung betroffen</Title>
+          <ogc:Filter>
+            <ogc:Not>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>direction</ogc:PropertyName>
+                <ogc:Literal>BOTH_DIRECTIONS</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+            </ogc:Not>
+          </ogc:Filter>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#ffffff</CssParameter>
+              <CssParameter name="stroke-width">3</CssParameter>
+              <CssParameter name="stroke-linecap">round</CssParameter>
+            </Stroke>
+            <PerpendicularOffset>2</PerpendicularOffset>
+          </LineSymbolizer>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#A93030</CssParameter>
+              <CssParameter name="stroke-width">2</CssParameter>
+              <CssParameter name="stroke-dasharray">4 2</CssParameter>
+            </Stroke>
+            <PerpendicularOffset>2</PerpendicularOffset>
+          </LineSymbolizer>
+        </Rule>
+        <Rule>
+          <Title>Einseitige Sperrung</Title>
+          <ogc:Filter>
+            <ogc:And>
+              <ogc:Not>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>direction</ogc:PropertyName>
+                  <ogc:Literal>BOTH_DIRECTIONS</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+              </ogc:Not>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>type</ogc:PropertyName>
+                <ogc:Literal>ROAD_CLOSED</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+            </ogc:And>
+          </ogc:Filter>
+          <PointSymbolizer>
+            <Geometry>
+              <ogc:Function name="startPoint">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+            </Geometry>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#A93030</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>9</Size>
+            </Graphic>
+          </PointSymbolizer>
+          <PointSymbolizer>
+            <Geometry>
+              <ogc:Function name="startPoint">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+            </Geometry>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#ffffff</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>6</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+        <Rule>
+          <Title>Einseitige Beeinträchtigung</Title>
+          <ogc:Filter>
+            <ogc:And>
+              <ogc:Not>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>direction</ogc:PropertyName>
+                  <ogc:Literal>BOTH_DIRECTIONS</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+              </ogc:Not>
+              <ogc:Not>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>type</ogc:PropertyName>
+                  <ogc:Literal>ROAD_CLOSED</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+              </ogc:Not>
+            </ogc:And>
+          </ogc:Filter>
+          <PointSymbolizer>
+            <Geometry>
+              <ogc:Function name="startPoint">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+            </Geometry>
+            <Graphic>
+              <Mark>
+                <WellKnownName>triangle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#A93030</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>11</Size>
+            </Graphic>
+          </PointSymbolizer>
+          <PointSymbolizer>
+            <Geometry>
+              <ogc:Function name="startPoint">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+            </Geometry>
+            <Graphic>
+              <Mark>
+                <WellKnownName>triangle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#ffffff</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>9</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+        <Rule>
+          <Title>Vollsperrung</Title>
+          <ogc:Filter>
+            <ogc:And>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>direction</ogc:PropertyName>
+                <ogc:Literal>BOTH_DIRECTIONS</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>type</ogc:PropertyName>
+                <ogc:Literal>ROAD_CLOSED</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+            </ogc:And>
+          </ogc:Filter>
+          <PointSymbolizer>
+            <Geometry>
+              <ogc:Function name="interiorPoint">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+            </Geometry>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#A93030</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>9</Size>
+            </Graphic>
+          </PointSymbolizer>
+          <PointSymbolizer>
+            <Geometry>
+              <ogc:Function name="interiorPoint">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+            </Geometry>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#ffffff</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>6</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+        <Rule>
+          <Title>Beeinträchtigung beider Fahrtrichtungen</Title>
+          <ogc:Filter>
+            <ogc:And>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>direction</ogc:PropertyName>
+                <ogc:Literal>BOTH_DIRECTIONS</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+              <ogc:Not>
+                <ogc:PropertyIsEqualTo>
+                  <ogc:PropertyName>type</ogc:PropertyName>
+                  <ogc:Literal>ROAD_CLOSED</ogc:Literal>
+                </ogc:PropertyIsEqualTo>
+              </ogc:Not>
+            </ogc:And>
+          </ogc:Filter>
+          <PointSymbolizer>
+            <Geometry>
+              <ogc:Function name="interiorPoint">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+            </Geometry>
+            <Graphic>
+              <Mark>
+                <WellKnownName>triangle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#A93030</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>11</Size>
+            </Graphic>
+          </PointSymbolizer>
+          <PointSymbolizer>
+            <Geometry>
+              <ogc:Function name="interiorPoint">
+                <ogc:PropertyName>geometry</ogc:PropertyName>
+              </ogc:Function>
+            </Geometry>
+            <Graphic>
+              <Mark>
+                <WellKnownName>triangle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#ffffff</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>9</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_traffic_roadworks_detailed.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_traffic_roadworks_detailed.xml
@@ -1,0 +1,13 @@
+<style>
+  <id>StyleInfoImpl--476372f4:18f3cd976b2:-7fd4</id>
+  <name>mdbw_traffic_roadworks_detailed</name>
+  <workspace>
+    <id>WorkspaceInfoImpl--48f676ef:18997a59df5:-7ff6</id>
+  </workspace>
+  <format>sld</format>
+  <languageVersion>
+    <version>1.0.0</version>
+  </languageVersion>
+  <filename>mdbw_traffic_roadworks_detailed.sld</filename>
+  <dateCreated>2024-05-03 12:17:45.759 UTC</dateCreated>
+</style>


### PR DESCRIPTION
# Changes
* replaced the styling `mdbw_traffic_roadworks_default` by a less detailed sld definition
* added old more detailed style settings to a new style called `mdbw_traffic_roadworks_detailed`
* increased geometry sizes of circles and triangles slightly
