### PR TITLE
update park-api, prepare release

### DIFF
--- a/.env
+++ b/.env
@@ -104,7 +104,7 @@ PARK_API_POSTGRES_USER=park-api
 PARK_API_POSTGRES_DB=park-api
 PARK_API_POSTGRES_HOST=park-api-db
 PARK_API_CELERY_BROKER_URL=amqp://park-api-rabbitmq
-PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.2.0
+PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.3.0
 PARK_API_DB_IMAGE=postgis/postgis:15-3.4-alpine
 
 # Caddy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
+### [2024-05-08]
 
-## [Unreleased, planned for 2024-05-07]
+### Added
+
+- Optional [cursor pagination at ParkAPI](https://github.com/ParkenDD/park-api-v3/pull/140)
+
+
+## [2024-05-07]
 
 ### Added
 


### PR DESCRIPTION
Adds a new release for cursor pagination at ParkAPI parking site endpoints.