### PR TITLE
gtfs-api: upgrade PostgREST to v12.2.0

### DIFF
--- a/.env
+++ b/.env
@@ -68,6 +68,7 @@ PGBOUNCER_POSTGRES_USER=postgres
 # gtfs-api variables
 IPL_GTFS_API_IMAGE=postgrest/postgrest:v12.2.0
 IPL_GTFS_API_PORT=4000
+IPL_GTFS_API_ADMIN_PORT=4002
 IPL_GTFS_API_PUBLIC_BASE_URL=http://localhost:8080/gtfs
 # > A hard limit to the number of rows PostgREST will fetch from a view, table, or stored procedure. Limits payload size for accidental or malicious requests.
 # We expect those people who want to mass-analyse GTFS data to just download the entire GTFS dataset.

--- a/.env
+++ b/.env
@@ -66,6 +66,7 @@ PGBOUNCER_IMAGE=bitnami/pgbouncer:1
 PGBOUNCER_POSTGRES_USER=postgres
 
 # gtfs-api variables
+IPL_GTFS_API_IMAGE=postgrest/postgrest:v12.2.0
 IPL_GTFS_API_PORT=4000
 IPL_GTFS_API_PUBLIC_BASE_URL=http://localhost:8080/gtfs
 # > A hard limit to the number of rows PostgREST will fetch from a view, table, or stored procedure. Limits payload size for accidental or malicious requests.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -571,7 +571,7 @@ services:
         condition: service_healthy
     links:
       - pgbouncer
-    image: postgrest/postgrest
+    image: ${IPL_GTFS_API_IMAGE:?missing/empty}
     ports:
       - ${IPL_GTFS_API_PORT}:3000
     read_only: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -574,6 +574,7 @@ services:
     image: ${IPL_GTFS_API_IMAGE:?missing/empty}
     ports:
       - ${IPL_GTFS_API_PORT}:3000
+      - ${IPL_GTFS_API_ADMIN_PORT:?missing/empty}:3001
     read_only: true
     environment:
       # connect via pgbouncer to regardless of the GTFS DBs' suffixes & improve performance
@@ -587,6 +588,7 @@ services:
       PGRST_DB_SCHEMAS: api
       PGRST_DB_ANON_ROLE: web_anon
       PGRST_DB_MAX_ROWS: ${IPL_GTFS_API_MAX_ROWS:?missing/empty}
+      PGRST_ADMIN_SERVER_PORT: 3001 # exposes health check & metrics
 
       # > Also set db-channel-enabled to false since LISTEN is not compatible with transaction pooling. Although it should not give any errors if left enabled.
       # https://postgrest.org/en/stable/references/connection_pool.html#external-connection-poolers


### PR DESCRIPTION
[PostgREST v12.2.0 release](https://github.com/PostgREST/postgrest/releases/tag/v12.2.0)

This PR exposes the host port 4002 which serves Prometheus metrics. They are already expected by the Ansible setup as of https://github.com/mobidata-bw/ipl-ansible/pull/56.