### PR TITLE
Add TMS support for roadworks layer

### DIFF
--- a/.env
+++ b/.env
@@ -82,7 +82,9 @@ IPL_GTFS_API_DOCS_PORT=4001
 # Geoserver variables
 GEOSERVER_PROXY_BASE_URL=http://localhost:8600/geoserver
 GEOSERVER_CSRF_WHITELIST=mobidata-bw.de
+# NOTE: When bumping GEOSERVER_IMAGE, mind to bump the GEOSERVER_PLUGIN_DYNAMIC_URLS accordingly
 GEOSERVER_IMAGE=geosolutionsit/geoserver:2.25.2
+GEOSERVER_PLUGIN_DYNAMIC_URLS=https://sourceforge.net/projects/geoserver/files/GeoServer/2.25.2/extensions/geoserver-2.25.2-vectortiles-plugin.zip
 GEOSERVER_PORT=8600
 GEOSERVER_INITIAL_MEMORY=512M
 GEOSERVER_MAXIMUM_MEMORY=4G

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
  * Addition of `capacity` attribute to sharing stations layers as `java.lang.Integer` in Geoserver
  * Addition of `photo_url` attribute to `parking_sites` and `parking_sites_bicycle`
+ * Add vector tiles support for layer `MobiData-BW:roadworks`.
  
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,8 @@ reload-geoserver:
 .PHONY: prepare-geoserver-workspace-for-commit
 prepare-geoserver-workspace-for-commit:
 	rsync -av --exclude='*/datastore.xml' var/geoserver/datadir/workspaces etc/geoserver
+	rsync -av var/geoserver/datadir/gwc etc/geoserver
+	rsync -av var/geoserver/datadir/gwc-layers etc/geoserver
 
 # GTFS data management
 # --------------------

--- a/bin/geoserver/geoserver-rest-reload.sh
+++ b/bin/geoserver/geoserver-rest-reload.sh
@@ -5,10 +5,15 @@
 # It differs in it's set options, i.e. disable trace output, enable failing: 
 set -eo pipefail
 #set -x
-echo "Copying data dir workspaces from GEOSERVER_DATA_DIR_CUSTOM to GEOSERVER_DATA_DIR"
+echo "Copying data dir workspaces, gwc and gcw-layers from GEOSERVER_DATA_DIR_CUSTOM to GEOSERVER_DATA_DIR"
 rm -rf $GEOSERVER_DATA_DIR/workspaces/*
 mkdir -p $GEOSERVER_DATA_DIR/workspaces/
-cp -R $GEOSERVER_DATA_DIR_CUSTOM/workspaces/* $GEOSERVER_DATA_DIR/workspaces 
+cp -R $GEOSERVER_DATA_DIR_CUSTOM/workspaces/* $GEOSERVER_DATA_DIR/workspaces
+mkdir -p $GEOSERVER_DATA_DIR/gwc/
+cp -R $GEOSERVER_DATA_DIR_CUSTOM/gwc/* $GEOSERVER_DATA_DIR/gwc
+mkdir -p $GEOSERVER_DATA_DIR/gwc-layers/
+cp -R $GEOSERVER_DATA_DIR_CUSTOM/gwc-layers/* $GEOSERVER_DATA_DIR/gwc-layers
+
 # /end mod
 #while [ "$(curl -s --retry-connrefused --retry 100 -I http://localhost:8080/geoserver/web/ 2>&1 |grep 200)" == "" ];do
 #  echo "Waiting for GeoServer to be Up and running"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -297,6 +297,7 @@ services:
       - GEOSERVER_DATA_DIR_CUSTOM=/var/geoserver/datadir_template/
       - GEOSERVER_LOGGING_PROFILE=${GEOSERVER_LOGGING_PROFILE}
       - GEOSERVER_CSRF_WHITELIST=${GEOSERVER_CSRF_WHITELIST:?missing/empty}
+      - PLUGIN_DYNAMIC_URLS=${GEOSERVER_PLUGIN_DYNAMIC_URLS:?missing/empty}
       - PROXY_BASE_URL=${GEOSERVER_PROXY_BASE_URL:?missing/empty}
       # All we want to do is set user.timezone and DALLOW_ENV_PARAMETRIZATION. Due to https://github.com/geosolutions-it/docker-geoserver/issues/133
       # we currently need to pass in all default properties already defined in the dockerfile

--- a/etc/geoserver/.gitignore
+++ b/etc/geoserver/.gitignore
@@ -1,3 +1,3 @@
 logs/
 temp/
-gwc/
+

--- a/etc/geoserver/gwc-gs.xml
+++ b/etc/geoserver/gwc-gs.xml
@@ -1,0 +1,45 @@
+<GeoServerGWCConfig>
+  <version>1.1.0</version>
+  <directWMSIntegrationEnabled>false</directWMSIntegrationEnabled>
+  <requireTiledParameter>true</requireTiledParameter>
+  <WMSCEnabled>true</WMSCEnabled>
+  <TMSEnabled>true</TMSEnabled>
+  <securityEnabled>false</securityEnabled>
+  <innerCachingEnabled>false</innerCachingEnabled>
+  <persistenceEnabled>true</persistenceEnabled>
+  <cacheProviderClass>class org.geowebcache.storage.blobstore.memory.guava.GuavaCacheProvider</cacheProviderClass>
+  <cacheConfigurations>
+    <entry>
+      <string>class org.geowebcache.storage.blobstore.memory.guava.GuavaCacheProvider</string>
+      <InnerCacheConfiguration>
+        <hardMemoryLimit>16</hardMemoryLimit>
+        <policy>NULL</policy>
+        <concurrencyLevel>4</concurrencyLevel>
+        <evictionTime>120</evictionTime>
+      </InnerCacheConfiguration>
+    </entry>
+  </cacheConfigurations>
+  <cacheLayersByDefault>true</cacheLayersByDefault>
+  <cacheNonDefaultStyles>true</cacheNonDefaultStyles>
+  <metaTilingX>4</metaTilingX>
+  <metaTilingY>4</metaTilingY>
+  <gutter>0</gutter>
+  <defaultCachingGridSetIds>
+    <string>EPSG:4326</string>
+    <string>EPSG:900913</string>
+  </defaultCachingGridSetIds>
+  <defaultCoverageCacheFormats>
+    <string>image/png</string>
+    <string>image/jpeg</string>
+  </defaultCoverageCacheFormats>
+  <defaultVectorCacheFormats>
+    <string>application/vnd.mapbox-vector-tile</string>
+    <string>image/png</string>
+    <string>image/jpeg</string>
+  </defaultVectorCacheFormats>
+  <defaultOtherCacheFormats>
+    <string>application/vnd.mapbox-vector-tile</string>
+    <string>image/png</string>
+    <string>image/jpeg</string>
+  </defaultOtherCacheFormats>
+</GeoServerGWCConfig>

--- a/etc/geoserver/gwc-layers/LayerInfoImpl--2f417ac5_18e2df033ce_-7ff0.xml
+++ b/etc/geoserver/gwc-layers/LayerInfoImpl--2f417ac5_18e2df033ce_-7ff0.xml
@@ -1,0 +1,55 @@
+<GeoServerTileLayer>
+  <id>LayerInfoImpl--2f417ac5:18e2df033ce:-7ff0</id>
+  <enabled>true</enabled>
+  <inMemoryCached>true</inMemoryCached>
+  <name>MobiData-BW:roadworks</name>
+  <mimeFormats>
+    <string>application/vnd.mapbox-vector-tile</string>
+    <string>image/png</string>
+  </mimeFormats>
+  <gridSubsets>
+    <gridSubset>
+      <gridSetName>EPSG:900913</gridSetName>
+      <extent>
+        <coords>
+          <double>843907.0449589812</double>
+          <double>6038330.219989197</double>
+          <double>1138685.913728067</double>
+          <double>6380978.261540302</double>
+        </coords>
+      </extent>
+      <zoomStop>18</zoomStop>
+      <maxCachedLevel>14</maxCachedLevel>
+    </gridSubset>
+    <gridSubset>
+      <gridSetName>EPSG:4326</gridSetName>
+      <extent>
+        <coords>
+          <double>7.58094596862793</double>
+          <double>47.58646011352539</double>
+          <double>10.228989601135254</double>
+          <double>49.62147521972656</double>
+        </coords>
+      </extent>
+    </gridSubset>
+  </gridSubsets>
+  <metaWidthHeight>
+    <int>4</int>
+    <int>4</int>
+  </metaWidthHeight>
+  <expireCache>60</expireCache>
+  <expireClients>30</expireClients>
+  <parameterFilters>
+    <styleParameterFilter>
+      <key>STYLES</key>
+      <defaultValue></defaultValue>
+      <allowedStyles class="sorted-set"/>
+      <availableStyles class="sorted-set">
+        <string>MobiData-BW:mdbw_traffic_roadworks_detailed</string>
+      </availableStyles>
+      <defaultStyle>MobiData-BW:mdbw_traffic_roadworks_default</defaultStyle>
+    </styleParameterFilter>
+  </parameterFilters>
+  <gutter>15</gutter>
+  <cacheWarningSkips/>
+</GeoServerTileLayer>

--- a/etc/geoserver/gwc/geowebcache-diskquota.xml
+++ b/etc/geoserver/gwc/geowebcache-diskquota.xml
@@ -1,0 +1,12 @@
+<gwcQuotaConfiguration>
+  <enabled>true</enabled>
+  <cacheCleanUpFrequency>10</cacheCleanUpFrequency>
+  <cacheCleanUpUnits>SECONDS</cacheCleanUpUnits>
+  <maxConcurrentCleanUps>2</maxConcurrentCleanUps>
+  <globalExpirationPolicyName>LFU</globalExpirationPolicyName>
+  <globalQuota>
+    <value>500</value>
+    <units>MiB</units>
+  </globalQuota>
+  <quotaStore>HSQL</quotaStore>
+</gwcQuotaConfiguration>

--- a/etc/geoserver/gwc/geowebcache.xml
+++ b/etc/geoserver/gwc/geowebcache.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gwcConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://geowebcache.org/schema/1.8.0"
+  xsi:schemaLocation="http://geowebcache.org/schema/1.8.0 http://geowebcache.org/schema/1.8.0/geowebcache.xsd">
+  <version>1.8.0</version>
+  <backendTimeout>120</backendTimeout>
+  <serviceInformation>
+    <title>MobiData BW GeoWebCache</title>
+    <description>Map tile service for Baden-Württemberg (DE-BW), part of MobiData BW, provided by NVBW.</description>
+    <keywords>
+      <string>WFS</string>
+      <string>WMS</string>
+      <string>WMTS</string>
+      <string>GEOWEBCACHE</string>
+    </keywords>
+    <serviceProvider>
+      <providerName>NVBW - Nahverkehrsgesellschaft Baden-Württemberg mbH</providerName>
+      <providerSite>http://mobidata-bw.de/</providerSite>
+      <individualName>Dr. Thorsten Fröhlinghaus</individualName>
+      <positionName>Technische Leitung Dateninfrastruktur</positionName>
+      <addressType>Work</addressType>
+      <addressStreet>Wilhelmsplatz 11</addressStreet>
+      <addressCity>Stuttgart</addressCity>
+      <addressAdministrativeArea>Baden-Württemberg</addressAdministrativeArea>
+      <addressPostalCode>70182</addressPostalCode>
+      <addressCountry>Deutschland</addressCountry>
+      <phoneNumber>+49 711 23991-138</phoneNumber>
+      <faxNumber>+49 711 23991-23</faxNumber>
+      <addressEmail>Thorsten.Froehlinghaus@nvbw.de</addressEmail>
+    </serviceProvider>
+    <fees>NONE</fees>
+    <accessConstraints>NONE</accessConstraints>
+  </serviceInformation>
+  <gridSets>
+  </gridSets>
+
+  <layers>
+  </layers>
+  
+</gwcConfiguration>


### PR DESCRIPTION
This PR adds TMS support for geoserver layer `MobiData-BW:roadworks`. 
To support TMS, the mirrored `geoserver-vectortiles` plugin is installed.

To add this e.g. to Leaflet, you could now add roadworks as

```js
L.tileLayer('https://api.mobidata-bw.de/geoserver/gwc/service/tms/1.0.0/MobiData-BW:roadworks@EPSG:900913@png/{z}/{x}/{-y}.png', {
         maxZoom: 18
      }).addTo(map);
```

Note the `-y`, which is one way to declare that this is a `TMS` layer which has `y` tileRow ordered from South to North, in contrast to standard `XYZ` having them ordered from North to South. The y-value which will be requested by Leaflet effectively calculated as `2^zoom-1 - y`. To learn more about differences of different standards, see e.g. this [Tiled Web Map Wikipedia article](https://en.wikipedia.org/wiki/Tiled_web_map).