### PR TITLE
remove tier_rotkreuz feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Removed
 
-* bird-bulle, bird-uster, bird-winterthur GBFS feeds
-* tier_rotkreuz GBFS feed
+* Removed GBFS feeds: bird-bulle, bird-uster, bird-winterthur, tier_rotkreuz
 
 ## Tasks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Removed
 
 * bird-bulle, bird-uster, bird-winterthur GBFS feeds
+* tier_rotkreuz GBFS feed
 
 ## Tasks
 

--- a/etc/lamassu/feedproviders.yml
+++ b/etc/lamassu/feedproviders.yml
@@ -614,16 +614,6 @@ lamassu:
         scheme: HTTP_HEADERS
         properties:
           Authorization: ${LAMASSU_SHAREDMOBILITY_CH_AUTHORIZATION}
-    - systemId: tier_rotkreuz
-      operatorId: TIE:Operator:tier
-      operatorName: Tier
-      codespace: TIE
-      url: "https://gbfs.prod.sharedmobility.ch/v2/gbfs/tier_rotkreuz/gbfs"
-      language: en
-      authentication:
-        scheme: HTTP_HEADERS
-        properties:
-          Authorization: ${LAMASSU_SHAREDMOBILITY_CH_AUTHORIZATION}
     - systemId: tier_stgallen
       operatorId: TIE:Operator:tier
       operatorName: Tier


### PR DESCRIPTION
tier_rotkreuz is disabled by opendata swiss