### PR TITLE
ParkAPI 0.8.0

### DIFF
--- a/.env
+++ b/.env
@@ -110,7 +110,7 @@ PARK_API_POSTGRES_USER=park-api
 PARK_API_POSTGRES_DB=park-api
 PARK_API_POSTGRES_HOST=park-api-db
 PARK_API_CELERY_BROKER_URL=amqp://park-api-rabbitmq
-PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.7.6
+PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.8.0
 PARK_API_DB_IMAGE=postgis/postgis:15-3.4-alpine
 
 # Caddy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Changes
 
-- ParkAPI 0.7.6 with [better logging](https://github.com/ParkenDD/park-api-v3/pull/178)
-  and [fixes in Karlsruhe converter](https://github.com/ParkenDD/parkapi-sources-v3/pull/75)
+- ParkAPI 0.8.0 with [better logging](https://github.com/ParkenDD/park-api-v3/pull/178) ,
+  [Goldbeck converter](https://github.com/ParkenDD/parkapi-sources-v3/pull/68) and
+  [fixes in Karlsruhe converter](https://github.com/ParkenDD/parkapi-sources-v3/pull/75)
 
-  
+
+
 ## 2024-07-16
 
 ## Changes


### PR DESCRIPTION
ParkAPI 0.8.0 with [better logging](https://github.com/ParkenDD/park-api-v3/pull/178) ,  [Goldbeck converter](https://github.com/ParkenDD/parkapi-sources-v3/pull/68) and  [fixes in Karlsruhe converter](https://github.com/ParkenDD/parkapi-sources-v3/pull/75)