### PR TITLE
Release 2024-07-31

### DIFF
--- a/.env
+++ b/.env
@@ -86,7 +86,7 @@ GEOSERVER_PROXY_BASE_URL=http://localhost:8600/geoserver
 GEOSERVER_CSRF_WHITELIST=mobidata-bw.de
 # NOTE: When bumping GEOSERVER_IMAGE, mind to bump the GEOSERVER_PLUGIN_DYNAMIC_URLS accordingly
 GEOSERVER_IMAGE=geosolutionsit/geoserver:2.25.3
-GEOSERVER_PLUGIN_DYNAMIC_URLS=https://sourceforge.net/projects/geoserver/files/GeoServer/2.25.2/extensions/geoserver-2.25.2-vectortiles-plugin.zip
+GEOSERVER_PLUGIN_DYNAMIC_URLS=https://sourceforge.net/projects/geoserver/files/GeoServer/2.25.3/extensions/geoserver-2.25.3-vectortiles-plugin.zip
 GEOSERVER_PORT=8600
 GEOSERVER_INITIAL_MEMORY=512M
 GEOSERVER_MAXIMUM_MEMORY=4G

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
+## 2024-07-31
+
+## Changes
+
+- Geoserver: Upgrade from 2.25.2 to 2.25.3 (see [geoserver/releases](https://github.com/geoserver/geoserver/releases/))
+
 ## 2024-07-23
 
 ## Changes


### PR DESCRIPTION
This PR documents the geoserver update and bumps vectortiles extension to geoserver version 2.25.3