### PR TITLE
ParkAPI 0.9.0

### DIFF
--- a/.env
+++ b/.env
@@ -110,7 +110,7 @@ PARK_API_POSTGRES_USER=park-api
 PARK_API_POSTGRES_DB=park-api
 PARK_API_POSTGRES_HOST=park-api-db
 PARK_API_CELERY_BROKER_URL=amqp://park-api-rabbitmq
-PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.8.0
+PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.9.0
 PARK_API_DB_IMAGE=postgis/postgis:15-3.4-alpine
 
 # Caddy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- ParkAPI 0.9.0 with [Swiss OpenData](https://github.com/ParkenDD/park-api-v3/blob/ff4d20ed47ebcdc1cc9bf5c9ea7fbf48218cba68/CHANGELOG.md#090)
+
+
 ### Changes
 
 - `gtfs-api`: Upgrade PostgREST from 12.2.2 to [12.2.3](https://github.com/PostgREST/postgrest/releases/tag/v12.2.3)
+- ParkAPI 0.9.0 with [Fixes for Ellwangen, Karlsruhe, Goldbeck, Ulm, Herrenberg, BFRK](https://github.com/ParkenDD/park-api-v3/blob/ff4d20ed47ebcdc1cc9bf5c9ea7fbf48218cba68/CHANGELOG.md#090):
+
 
 ## 2024-07-31
 


### PR DESCRIPTION
ParkAPI 0.9.0 with several fixes and new swiss opendata parking sites: https://github.com/ParkenDD/park-api-v3/blob/ff4d20ed47ebcdc1cc9bf5c9ea7fbf48218cba68/CHANGELOG.md#090