### PR TITLE
Geoserver sharing layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 - GBFS Feed for new carsharing provided flinkster added (via x2gbs version 2024-09-05T12-13)
-
+- GeoServer: Added `station_id` to `MobiData-BW:sharing_vehicles` and removed sharing stations where `station_id` is null
+- GeoServer: Added the new category "Keine Echtzeitdaten" (no realtime data) to the `mdbw_sharing_stations_default` style
 
 ## 2024-09-03
 

--- a/etc/geoserver/workspaces/MobiData-BW/ipl-db/sharing_vehicles/featuretype.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/ipl-db/sharing_vehicles/featuretype.xml
@@ -51,6 +51,7 @@
   <simpleConversionEnabled>false</simpleConversionEnabled>
   <internationalTitle/>
   <internationalAbstract/>
+  <cqlFilter>station_id is null</cqlFilter>
   <maxFeatures>0</maxFeatures>
   <numDecimals>0</numDecimals>
   <padWithZeros>false</padWithZeros>
@@ -64,6 +65,16 @@
       <binding>java.lang.String</binding>
       <description>
         <de>ID des Fahrzeugs</de>
+      </description>
+    </attribute>
+    <attribute>
+      <name>station_id</name>
+      <minOccurs>0</minOccurs>
+      <maxOccurs>1</maxOccurs>
+      <nillable>true</nillable>
+      <binding>java.lang.String</binding>
+      <description>
+        <de>ID der zum Fahrzeug dazugehörigen Station</de>
       </description>
     </attribute>
     <attribute>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_stations_default.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_stations_default.sld
@@ -1,21 +1,64 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <StyledLayerDescriptor version="1.0.0"
-  xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd"
-  xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc"
-  xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
+                       xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd"
+                       xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc"
+                       xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NamedLayer>
     <Name>mdbw_sharing_stations_default</Name>
     <UserStyle>
-      <Title>MobiData-BW Sharing-Stationen</Title>
+      <Title>MobiData BW® - Sharing-Stationen</Title>
       <FeatureTypeStyle>
+        <Rule>
+          <Title>Keine Echtzeitdaten</Title>
+          <ogc:Filter>
+            <ogc:Or>
+              <ogc:PropertyIsLike wildCard="*" singleChar="#" escape="!">
+                <ogc:PropertyName>feed_id</ogc:PropertyName>
+                <ogc:Literal>stadtmobil*</ogc:Literal>
+              </ogc:PropertyIsLike>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>feed_id</ogc:PropertyName>
+                <ogc:Literal>my-e-car</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+            </ogc:Or>
+          </ogc:Filter>
+          <PointSymbolizer>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#615fdf</CssParameter>
+                </Fill>
+                <Stroke>
+                  <CssParameter name="stroke">#000000</CssParameter>
+                  <CssParameter name="stroke-width">0.5</CssParameter>
+                </Stroke>
+              </Mark>
+              <Size>10</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
         <Rule>
           <Title>Fahrzeuge verfügbar</Title>
           <ogc:Filter>
-            <ogc:PropertyIsGreaterThan>
-              <ogc:PropertyName>num_vehicles_available</ogc:PropertyName>
-              <ogc:Literal>0</ogc:Literal>
-            </ogc:PropertyIsGreaterThan>
+            <ogc:And>
+              <ogc:Not>
+                <ogc:Or>
+                  <ogc:PropertyIsLike wildCard="*" singleChar="#" escape="!">
+                    <ogc:PropertyName>feed_id</ogc:PropertyName>
+                    <ogc:Literal>stadtmobil*</ogc:Literal>
+                  </ogc:PropertyIsLike>
+                  <ogc:PropertyIsEqualTo>
+                    <ogc:PropertyName>feed_id</ogc:PropertyName>
+                    <ogc:Literal>my-e-car</ogc:Literal>
+                  </ogc:PropertyIsEqualTo>
+                </ogc:Or>
+              </ogc:Not>
+              <ogc:PropertyIsGreaterThan>
+                <ogc:PropertyName>num_vehicles_available</ogc:PropertyName>
+                <ogc:Literal>0</ogc:Literal>
+              </ogc:PropertyIsGreaterThan>
+            </ogc:And>
           </ogc:Filter>
           <PointSymbolizer>
             <Graphic>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_stations_default.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_stations_default.xml
@@ -10,5 +10,5 @@
   </languageVersion>
   <filename>mdbw_sharing_stations_default.sld</filename>
   <dateCreated>2023-12-18 21:41:57.77 UTC</dateCreated>
-  <dateModified>2023-12-18 21:49:38.605 UTC</dateModified>
+  <dateModified>2024-09-09 07:25:21.266 UTC</dateModified>
 </style>


### PR DESCRIPTION
# Changes

## MobiData-BW:sharing_vehicles

* added `station_id` to `MobiData-BW:sharing_vehicles`
* added cql filter to only include vehicles where `station_id is null`

## MobiData-BW:sharing_stations

* added new layer "Keine Echtzeitdaten" to `mdbw_sharing_stations_default`