### PR TITLE
Geoserver

### DIFF
--- a/.env
+++ b/.env
@@ -88,8 +88,8 @@ IPL_GTFS_API_DOCS_PORT=4001
 GEOSERVER_PROXY_BASE_URL=http://localhost:8600/geoserver
 GEOSERVER_CSRF_WHITELIST=mobidata-bw.de
 # NOTE: When bumping GEOSERVER_IMAGE, mind to bump the GEOSERVER_PLUGIN_DYNAMIC_URLS accordingly
-GEOSERVER_IMAGE=geosolutionsit/geoserver:2.25.3
-GEOSERVER_PLUGIN_DYNAMIC_URLS=https://sourceforge.net/projects/geoserver/files/GeoServer/2.25.3/extensions/geoserver-2.25.3-vectortiles-plugin.zip https://sourceforge.net/projects/geoserver/files/GeoServer/2.25.3/extensions/geoserver-2.25.3-inspire-plugin.zip
+GEOSERVER_IMAGE=geosolutionsit/geoserver:2.26.0
+GEOSERVER_PLUGIN_DYNAMIC_URLS=https://sourceforge.net/projects/geoserver/files/GeoServer/2.26.0/extensions/geoserver-2.26.0-vectortiles-plugin.zip https://sourceforge.net/projects/geoserver/files/GeoServer/2.26.0/extensions/geoserver-2.26.0-inspire-plugin.zip
 GEOSERVER_PORT=8600
 GEOSERVER_INITIAL_MEMORY=512M
 GEOSERVER_MAXIMUM_MEMORY=4G

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [upcoming release]
 
+### Added
+- GeoServer: added descriptions to `parking_sites` attributes; updated `MobiData-BW:mdbw_sharing_stations_default` for current and upcoming static GBFS feeds
+
 ### Changed
 - `lamassu`: upgraded [`lamassu`](https://github.com/entur/lamassu) to [2024-09-27T11-21](https://hub.docker.com/layers/entur/lamassu/2024-09-27T11-21/images/sha256-0f849baac422c1af11e2844e7dcd540a81a36414805e22c75243be2cea375a85?context=explore). This i.e. includes the `stationEntityCacheMinimumTtl` and `stationEntityCacheMaximumTtl`configuration options.
+- GeoServer: updated GeoServer from 2.25.3 to 2.26.0; renamed `parking_sites` to `parking_sites_car`
 
 ## 2024-10-01
 

--- a/etc/geoserver/workspaces/MobiData-BW/park-api-db/parking_sites_bicycle/featuretype.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/park-api-db/parking_sites_bicycle/featuretype.xml
@@ -47,7 +47,7 @@
     <entry key="JDBC_VIRTUAL_TABLE">
       <virtualTable>
         <name>parking_sites_bicycle</name>
-        <sql>SELECT id, source_id, original_uid, purpose, name, operator_name, public_url, photo_url, address, description, type, max_stay, has_lighting, fee_description, has_fee, park_and_ride_type, has_realtime_data,  realtime_opening_status, lat, lon, capacity, realtime_capacity, realtime_free_capacity,  capacity_charging, realtime_capacity_charging, realtime_free_capacity_charging, opening_hours, is_covered, supervision_type, related_location, geometry, created_at, modified_at, static_data_updated_at, realtime_data_updated_at FROM parking_site&#xd;
+        <sql>SELECT id, source_id, original_uid, purpose, name, operator_name, public_url, photo_url, address, description, type, max_stay, has_lighting, fee_description, has_fee, park_and_ride_type, has_realtime_data,  realtime_opening_status, capacity, realtime_capacity, realtime_free_capacity,  capacity_charging, realtime_capacity_charging, realtime_free_capacity_charging, opening_hours, is_covered, supervision_type, related_location, geometry, created_at, modified_at, static_data_updated_at, realtime_data_updated_at FROM parking_site&#xd;
 WHERE purpose=&apos;BIKE&apos;
 </sql>
         <escapeSql>false</escapeSql>
@@ -84,6 +84,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.Long</binding>
+      <description>
+        <de>ID der Parkanlage (von parkAPI erzeugt)</de>
+      </description>
     </attribute>
     <attribute>
       <name>source_id</name>
@@ -91,6 +94,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.Long</binding>
+      <description>
+        <de>ID des Datengebers (von parkAPI erzeugt)</de>
+      </description>
     </attribute>
     <attribute>
       <name>original_uid</name>
@@ -98,6 +104,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Ursprüngliche ID der Parkanlage beim Datengeber</de>
+      </description>
     </attribute>
     <attribute>
       <name>purpose</name>
@@ -105,6 +114,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Zweck der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>name</name>
@@ -112,6 +124,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Name der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>operator_name</name>
@@ -119,6 +134,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Betreiber der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>public_url</name>
@@ -126,6 +144,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Link zu weiterführenden Informationen der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>photo_url</name>
@@ -133,6 +154,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Link zu einem Foto der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>address</name>
@@ -140,6 +164,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Adresse der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>description</name>
@@ -147,6 +174,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Beschreibung</de>
+      </description>
     </attribute>
     <attribute>
       <name>type</name>
@@ -154,6 +184,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Art der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>max_stay</name>
@@ -161,6 +194,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Maximale Parkdauer</de>
+      </description>
     </attribute>
     <attribute>
       <name>has_lighting</name>
@@ -168,6 +204,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Boolean</binding>
+      <description>
+        <de>Beleuchtung?</de>
+      </description>
     </attribute>
     <attribute>
       <name>fee_description</name>
@@ -175,6 +214,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Beschreibung der Gebühren</de>
+      </description>
     </attribute>
     <attribute>
       <name>has_fee</name>
@@ -182,6 +224,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Boolean</binding>
+      <description>
+        <de>Gebührenpflichtig?</de>
+      </description>
     </attribute>
     <attribute>
       <name>park_and_ride_type</name>
@@ -189,6 +234,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Art der B+R-Anlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>has_realtime_data</name>
@@ -196,27 +244,19 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.Boolean</binding>
+      <description>
+        <de>Echtzeitdaten?</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_opening_status</name>
-      <minOccurs>1</minOccurs>
+      <minOccurs>0</minOccurs>
       <maxOccurs>1</maxOccurs>
-      <nillable>false</nillable>
+      <nillable>true</nillable>
       <binding>java.lang.String</binding>
-    </attribute>
-    <attribute>
-      <name>lat</name>
-      <minOccurs>1</minOccurs>
-      <maxOccurs>1</maxOccurs>
-      <nillable>false</nillable>
-      <binding>java.math.BigDecimal</binding>
-    </attribute>
-    <attribute>
-      <name>lon</name>
-      <minOccurs>1</minOccurs>
-      <maxOccurs>1</maxOccurs>
-      <nillable>false</nillable>
-      <binding>java.math.BigDecimal</binding>
+      <description>
+        <de>Echtzeit-Status der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>capacity</name>
@@ -224,20 +264,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.Integer</binding>
-    </attribute>
-    <attribute>
-      <name>realtime_capacity</name>
-      <minOccurs>0</minOccurs>
-      <maxOccurs>1</maxOccurs>
-      <nillable>true</nillable>
-      <binding>java.lang.Integer</binding>
-    </attribute>
-    <attribute>
-      <name>realtime_free_capacity</name>
-      <minOccurs>0</minOccurs>
-      <maxOccurs>1</maxOccurs>
-      <nillable>true</nillable>
-      <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Stellplätze</de>
+      </description>
     </attribute>
     <attribute>
       <name>capacity_charging</name>
@@ -245,6 +274,29 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Stellplätze mit Lademöglichkeit</de>
+      </description>
+    </attribute>
+    <attribute>
+      <name>realtime_capacity</name>
+      <minOccurs>0</minOccurs>
+      <maxOccurs>1</maxOccurs>
+      <nillable>true</nillable>
+      <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Stellplätze (Echtzeit)</de>
+      </description>
+    </attribute>
+    <attribute>
+      <name>realtime_free_capacity</name>
+      <minOccurs>0</minOccurs>
+      <maxOccurs>1</maxOccurs>
+      <nillable>true</nillable>
+      <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl freier Stellplätze (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_capacity_charging</name>
@@ -252,6 +304,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Stellplätze mit Lademöglichkeit (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_free_capacity_charging</name>
@@ -259,6 +314,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl freier Stellplätze mit Lademöglichkeit (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>opening_hours</name>
@@ -266,6 +324,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Öffnungszeiten</de>
+      </description>
     </attribute>
     <attribute>
       <name>is_covered</name>
@@ -273,6 +334,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Boolean</binding>
+      <description>
+        <de>Überdacht?</de>
+      </description>
     </attribute>
     <attribute>
       <name>supervision_type</name>
@@ -280,6 +344,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Art der Überwachung</de>
+      </description>
     </attribute>
     <attribute>
       <name>related_location</name>
@@ -287,6 +354,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Ortsbezug der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>geometry</name>
@@ -294,6 +364,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>org.locationtech.jts.geom.Point</binding>
+      <description>
+        <de>Koordinate der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>created_at</name>
@@ -301,6 +374,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.sql.Timestamp</binding>
+      <description>
+        <de>Erstellungsdatum in der parkAPI</de>
+      </description>
     </attribute>
     <attribute>
       <name>modified_at</name>
@@ -308,6 +384,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.sql.Timestamp</binding>
+      <description>
+        <de>Zeitpunkt der letzten Änderung in der parkAPI</de>
+      </description>
     </attribute>
     <attribute>
       <name>static_data_updated_at</name>
@@ -315,6 +394,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.sql.Timestamp</binding>
+      <description>
+        <de>Letzter Aktualisierungszeitpunkt der statischen Daten</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_data_updated_at</name>
@@ -322,6 +404,9 @@ WHERE purpose=&apos;BIKE&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.sql.Timestamp</binding>
+      <description>
+        <de>Letzter Aktualisierungszeitpunkt der Echtzeitdaten</de>
+      </description>
     </attribute>
   </attributes>
   <overridingServiceSRS>false</overridingServiceSRS>

--- a/etc/geoserver/workspaces/MobiData-BW/park-api-db/parking_sites_bicycle/layer.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/park-api-db/parking_sites_bicycle/layer.xml
@@ -18,5 +18,5 @@
     <logoHeight>0</logoHeight>
   </attribution>
   <dateCreated>2024-05-06 13:29:29.385 UTC</dateCreated>
-  <dateModified>2024-09-26 13:10:17.22 UTC</dateModified>
+  <dateModified>2024-10-04 09:01:04.906 UTC</dateModified>
 </layer>

--- a/etc/geoserver/workspaces/MobiData-BW/park-api-db/parking_sites_car/featuretype.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/park-api-db/parking_sites_car/featuretype.xml
@@ -1,7 +1,7 @@
 <featureType>
   <id>FeatureTypeInfoImpl--5bcdf8b:18bc88075ee:-7ffa</id>
-  <name>parking_sites</name>
-  <nativeName>parking_sites</nativeName>
+  <name>parking_sites_car</name>
+  <nativeName>parking_sites_car</nativeName>
   <namespace>
     <id>NamespaceInfoImpl--48f676ef:18997a59df5:-7ff5</id>
   </namespace>
@@ -11,6 +11,7 @@
     <string>parking_sites</string>
     <string>Parkplätze\@language=de\;</string>
     <string>Parkhäuser\@language=de\;</string>
+    <string>Autoparken\@language=de\;</string>
   </keywords>
   <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
   DATUM[&quot;World Geodetic System 1984&quot;, 
@@ -46,8 +47,8 @@
     </entry>
     <entry key="JDBC_VIRTUAL_TABLE">
       <virtualTable>
-        <name>parking_sites</name>
-        <sql>SELECT id, source_id, original_uid, name, operator_name, public_url, photo_url, address, description, type, max_stay, has_lighting, fee_description, has_fee, park_and_ride_type, has_realtime_data, realtime_opening_status, lat, lon, capacity, capacity_disabled, capacity_woman, capacity_family, capacity_charging, capacity_carsharing, capacity_truck, capacity_bus, realtime_capacity, realtime_capacity_disabled, realtime_capacity_woman, realtime_capacity_family, realtime_capacity_charging, realtime_capacity_carsharing, realtime_capacity_truck, realtime_capacity_bus, realtime_free_capacity, realtime_free_capacity_disabled, realtime_free_capacity_woman, realtime_free_capacity_family, realtime_free_capacity_charging, realtime_free_capacity_carsharing, realtime_free_capacity_truck, realtime_free_capacity_bus,  opening_hours, max_height, purpose, is_covered, supervision_type, related_location, geometry, created_at, modified_at, static_data_updated_at, realtime_data_updated_at FROM parking_site&#xd;
+        <name>parking_sites_car</name>
+        <sql>SELECT id, source_id, original_uid, name, operator_name, public_url, photo_url, address, description, type, max_stay, has_lighting, fee_description, has_fee, park_and_ride_type, has_realtime_data, realtime_opening_status, capacity, capacity_disabled, capacity_woman, capacity_family, capacity_charging, capacity_carsharing, capacity_truck, capacity_bus, realtime_capacity, realtime_capacity_disabled, realtime_capacity_woman, realtime_capacity_family, realtime_capacity_charging, realtime_capacity_carsharing, realtime_capacity_truck, realtime_capacity_bus, realtime_free_capacity, realtime_free_capacity_disabled, realtime_free_capacity_woman, realtime_free_capacity_family, realtime_free_capacity_charging, realtime_free_capacity_carsharing, realtime_free_capacity_truck, realtime_free_capacity_bus,  opening_hours, max_height, purpose, is_covered, supervision_type, related_location, geometry, created_at, modified_at, static_data_updated_at, realtime_data_updated_at FROM parking_site&#xd;
 WHERE purpose=&apos;CAR&apos;
 </sql>
         <escapeSql>false</escapeSql>
@@ -84,6 +85,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.Long</binding>
+      <description>
+        <de>ID der Parkanlage (von parkAPI erzeugt)</de>
+      </description>
     </attribute>
     <attribute>
       <name>source_id</name>
@@ -91,6 +95,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.Long</binding>
+      <description>
+        <de>ID des Datengebers (von parkAPI erzeugt)</de>
+      </description>
     </attribute>
     <attribute>
       <name>original_uid</name>
@@ -98,6 +105,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Ursprüngliche ID der Parkanlage beim Datengeber</de>
+      </description>
     </attribute>
     <attribute>
       <name>purpose</name>
@@ -105,6 +115,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Zweck der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>name</name>
@@ -112,6 +125,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Name der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>operator_name</name>
@@ -119,6 +135,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Betreiber der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>public_url</name>
@@ -126,6 +145,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Link zur Webseite</de>
+      </description>
     </attribute>
     <attribute>
       <name>photo_url</name>
@@ -133,6 +155,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Link zu einem Foto der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>address</name>
@@ -140,6 +165,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Adresse der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>description</name>
@@ -147,6 +175,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Beschreibung</de>
+      </description>
     </attribute>
     <attribute>
       <name>type</name>
@@ -154,6 +185,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Art der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>max_stay</name>
@@ -161,6 +195,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Maximale Parkdauer</de>
+      </description>
     </attribute>
     <attribute>
       <name>has_lighting</name>
@@ -168,13 +205,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Boolean</binding>
-    </attribute>
-    <attribute>
-      <name>fee_description</name>
-      <minOccurs>0</minOccurs>
-      <maxOccurs>1</maxOccurs>
-      <nillable>true</nillable>
-      <binding>java.lang.String</binding>
+      <description>
+        <de>Beleuchtung?</de>
+      </description>
     </attribute>
     <attribute>
       <name>has_fee</name>
@@ -182,6 +215,19 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Boolean</binding>
+      <description>
+        <de>Gebührenpflichtig?</de>
+      </description>
+    </attribute>
+    <attribute>
+      <name>fee_description</name>
+      <minOccurs>0</minOccurs>
+      <maxOccurs>1</maxOccurs>
+      <nillable>true</nillable>
+      <binding>java.lang.String</binding>
+      <description>
+        <de>Beschreibung der Gebühren</de>
+      </description>
     </attribute>
     <attribute>
       <name>park_and_ride_type</name>
@@ -189,6 +235,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Art der P+R-Anlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>has_realtime_data</name>
@@ -196,27 +245,19 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.Boolean</binding>
+      <description>
+        <de>Echtzeitdaten?</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_opening_status</name>
-      <minOccurs>1</minOccurs>
+      <minOccurs>0</minOccurs>
       <maxOccurs>1</maxOccurs>
-      <nillable>false</nillable>
+      <nillable>true</nillable>
       <binding>java.lang.String</binding>
-    </attribute>
-    <attribute>
-      <name>lat</name>
-      <minOccurs>1</minOccurs>
-      <maxOccurs>1</maxOccurs>
-      <nillable>false</nillable>
-      <binding>java.math.BigDecimal</binding>
-    </attribute>
-    <attribute>
-      <name>lon</name>
-      <minOccurs>1</minOccurs>
-      <maxOccurs>1</maxOccurs>
-      <nillable>false</nillable>
-      <binding>java.math.BigDecimal</binding>
+      <description>
+        <de>Echtzeit-Status der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>capacity</name>
@@ -224,6 +265,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Stellplätze</de>
+      </description>
     </attribute>
     <attribute>
       <name>capacity_disabled</name>
@@ -231,6 +275,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Behinderten-Stellplätze</de>
+      </description>
     </attribute>
     <attribute>
       <name>capacity_woman</name>
@@ -238,6 +285,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Frauen-Stellplätze</de>
+      </description>
     </attribute>
     <attribute>
       <name>capacity_family</name>
@@ -245,6 +295,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Familien-Stellplätze</de>
+      </description>
     </attribute>
     <attribute>
       <name>capacity_charging</name>
@@ -252,6 +305,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Stellplätze mit Lademöglichkeit</de>
+      </description>
     </attribute>
     <attribute>
       <name>capacity_carsharing</name>
@@ -259,6 +315,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Carsharing-Stellplätze</de>
+      </description>
     </attribute>
     <attribute>
       <name>capacity_truck</name>
@@ -266,6 +325,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl LKW-Stellplätze</de>
+      </description>
     </attribute>
     <attribute>
       <name>capacity_bus</name>
@@ -273,6 +335,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Bus-Stellplätze</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_capacity</name>
@@ -280,6 +345,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Stellplätze (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_capacity_disabled</name>
@@ -287,6 +355,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Behinderten-Stellplätze (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_capacity_woman</name>
@@ -294,6 +365,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Frauen-Stellplätze (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_capacity_family</name>
@@ -301,6 +375,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Familien-Stellplätze (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_capacity_charging</name>
@@ -308,6 +385,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Stellplätze mit Lademöglichkeit (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_capacity_carsharing</name>
@@ -315,6 +395,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Carsharing-Stellplätze (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_capacity_truck</name>
@@ -322,6 +405,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl LKW-Stellplätze (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_capacity_bus</name>
@@ -329,6 +415,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Bus-Stellplätze (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_free_capacity</name>
@@ -336,6 +425,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl freier Stellplätze (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_free_capacity_disabled</name>
@@ -343,6 +435,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl freier Behinderten-Stellplätze (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_free_capacity_woman</name>
@@ -350,6 +445,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl freier Frauen-Stellplätze (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_free_capacity_family</name>
@@ -357,6 +455,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl freier Familien-Stellplätze (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_free_capacity_charging</name>
@@ -364,6 +465,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl freier Stellplätze mit Lademöglichkeit (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_free_capacity_carsharing</name>
@@ -371,6 +475,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl freier Carsharing-Stellplätze (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_free_capacity_truck</name>
@@ -378,6 +485,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl freier LKW-Stellplätze (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_free_capacity_bus</name>
@@ -385,6 +495,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl freier Bus-Stellplätze (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>opening_hours</name>
@@ -392,6 +505,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Öffnungszeiten</de>
+      </description>
     </attribute>
     <attribute>
       <name>max_height</name>
@@ -399,6 +515,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Maximale Einfahrtshöhe</de>
+      </description>
     </attribute>
     <attribute>
       <name>is_covered</name>
@@ -406,6 +525,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Boolean</binding>
+      <description>
+        <de>Überdacht?</de>
+      </description>
     </attribute>
     <attribute>
       <name>supervision_type</name>
@@ -413,6 +535,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Art der Überwachung</de>
+      </description>
     </attribute>
     <attribute>
       <name>related_location</name>
@@ -420,6 +545,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Ortsbezug der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>geometry</name>
@@ -427,6 +555,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>org.locationtech.jts.geom.Point</binding>
+      <description>
+        <de>Koordinate der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>created_at</name>
@@ -434,6 +565,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.sql.Timestamp</binding>
+      <description>
+        <de>Erstellungsdatum in der parkAPI</de>
+      </description>
     </attribute>
     <attribute>
       <name>modified_at</name>
@@ -441,6 +575,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.sql.Timestamp</binding>
+      <description>
+        <de>Zeitpunkt der letzten Änderung in der parkAPI</de>
+      </description>
     </attribute>
     <attribute>
       <name>static_data_updated_at</name>
@@ -448,6 +585,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.sql.Timestamp</binding>
+      <description>
+        <de>Letzter Aktualisierungszeitpunkt der statischen Daten</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_data_updated_at</name>
@@ -455,6 +595,9 @@ WHERE purpose=&apos;CAR&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.sql.Timestamp</binding>
+      <description>
+        <de>Letzter Aktualisierungszeitpunkt der Echtzeitdaten</de>
+      </description>
     </attribute>
   </attributes>
   <overridingServiceSRS>false</overridingServiceSRS>

--- a/etc/geoserver/workspaces/MobiData-BW/park-api-db/parking_sites_car/layer.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/park-api-db/parking_sites_car/layer.xml
@@ -1,5 +1,5 @@
 <layer>
-  <name>parking_sites</name>
+  <name>parking_sites_car</name>
   <id>LayerInfoImpl--5bcdf8b:18bc88075ee:-7ff9</id>
   <type>VECTOR</type>
   <defaultStyle>
@@ -18,5 +18,5 @@
     <logoHeight>0</logoHeight>
   </attribution>
   <dateCreated>2023-11-13 11:50:05.514 UTC</dateCreated>
-  <dateModified>2024-09-26 13:08:41.232 UTC</dateModified>
+  <dateModified>2024-10-04 09:06:19.751 UTC</dateModified>
 </layer>

--- a/etc/geoserver/workspaces/MobiData-BW/park-api-db/parking_sites_item/featuretype.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/park-api-db/parking_sites_item/featuretype.xml
@@ -43,7 +43,7 @@
     <entry key="JDBC_VIRTUAL_TABLE">
       <virtualTable>
         <name>parking_sites_item</name>
-        <sql>SELECT id, source_id, original_uid, purpose, name, operator_name, public_url, photo_url, address, description, type, max_stay, has_lighting, fee_description, has_fee, park_and_ride_type, has_realtime_data,  realtime_opening_status, lat, lon, capacity, realtime_capacity, realtime_free_capacity,  capacity_charging, realtime_capacity_charging, realtime_free_capacity_charging, opening_hours, is_covered, supervision_type, related_location, geometry, created_at, modified_at, static_data_updated_at, realtime_data_updated_at FROM parking_site&#xd;
+        <sql>SELECT id, source_id, original_uid, purpose, name, operator_name, public_url, photo_url, address, description, type, max_stay, has_lighting, fee_description, has_fee, park_and_ride_type, has_realtime_data,  realtime_opening_status, capacity, realtime_capacity, realtime_free_capacity,  capacity_charging, realtime_capacity_charging, realtime_free_capacity_charging, opening_hours, is_covered, supervision_type, related_location, geometry, created_at, modified_at, static_data_updated_at, realtime_data_updated_at FROM parking_site&#xd;
 WHERE purpose=&apos;ITEM&apos;
 </sql>
         <escapeSql>false</escapeSql>
@@ -55,7 +55,7 @@ WHERE purpose=&apos;ITEM&apos;
         </geometry>
       </virtualTable>
     </entry>
-  <entry key="time">
+    <entry key="time">
       <dimensionInfo>
         <enabled>false</enabled>
       </dimensionInfo>
@@ -80,6 +80,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.Long</binding>
+      <description>
+        <de>ID der Parkanlage (von parkAPI erzeugt)</de>
+      </description>
     </attribute>
     <attribute>
       <name>source_id</name>
@@ -87,6 +90,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.Long</binding>
+      <description>
+        <de>ID des Datengebers (von parkAPI erzeugt)</de>
+      </description>
     </attribute>
     <attribute>
       <name>original_uid</name>
@@ -94,6 +100,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Ursprüngliche ID der Parkanlage beim Datengeber</de>
+      </description>
     </attribute>
     <attribute>
       <name>purpose</name>
@@ -101,6 +110,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Zweck der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>name</name>
@@ -108,27 +120,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.String</binding>
-    </attribute>
-    <attribute>
-      <name>operator_name</name>
-      <minOccurs>0</minOccurs>
-      <maxOccurs>1</maxOccurs>
-      <nillable>true</nillable>
-      <binding>java.lang.String</binding>
-    </attribute>
-    <attribute>
-      <name>public_url</name>
-      <minOccurs>0</minOccurs>
-      <maxOccurs>1</maxOccurs>
-      <nillable>true</nillable>
-      <binding>java.lang.String</binding>
-    </attribute>
-    <attribute>
-      <name>photo_url</name>
-      <minOccurs>0</minOccurs>
-      <maxOccurs>1</maxOccurs>
-      <nillable>true</nillable>
-      <binding>java.lang.String</binding>
+      <description>
+        <de>Name der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>address</name>
@@ -136,6 +130,39 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Adresse der Parkanlage</de>
+      </description>
+    </attribute>
+    <attribute>
+      <name>operator_name</name>
+      <minOccurs>0</minOccurs>
+      <maxOccurs>1</maxOccurs>
+      <nillable>true</nillable>
+      <binding>java.lang.String</binding>
+      <description>
+        <de>Betreiber der Parkanlage</de>
+      </description>
+    </attribute>
+    <attribute>
+      <name>public_url</name>
+      <minOccurs>0</minOccurs>
+      <maxOccurs>1</maxOccurs>
+      <nillable>true</nillable>
+      <binding>java.lang.String</binding>
+      <description>
+        <de>Link zu weiterführenden Informationen der Parkanlage</de>
+      </description>
+    </attribute>
+    <attribute>
+      <name>photo_url</name>
+      <minOccurs>0</minOccurs>
+      <maxOccurs>1</maxOccurs>
+      <nillable>true</nillable>
+      <binding>java.lang.String</binding>
+      <description>
+        <de>Link zu einem Foto der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>description</name>
@@ -143,6 +170,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Beschreibung</de>
+      </description>
     </attribute>
     <attribute>
       <name>type</name>
@@ -150,6 +180,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Art der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>max_stay</name>
@@ -157,6 +190,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Maximale Parkdauer</de>
+      </description>
     </attribute>
     <attribute>
       <name>has_lighting</name>
@@ -164,6 +200,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Boolean</binding>
+      <description>
+        <de>Beleuchtung?</de>
+      </description>
     </attribute>
     <attribute>
       <name>fee_description</name>
@@ -171,6 +210,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Beschreibung der Gebühren</de>
+      </description>
     </attribute>
     <attribute>
       <name>has_fee</name>
@@ -178,6 +220,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Boolean</binding>
+      <description>
+        <de>Gebührenpflichtig?</de>
+      </description>
     </attribute>
     <attribute>
       <name>park_and_ride_type</name>
@@ -185,6 +230,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Art der B+R-Anlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>has_realtime_data</name>
@@ -192,27 +240,19 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.Boolean</binding>
+      <description>
+        <de>Echtzeitdaten?</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_opening_status</name>
-      <minOccurs>1</minOccurs>
+      <minOccurs>0</minOccurs>
       <maxOccurs>1</maxOccurs>
-      <nillable>false</nillable>
+      <nillable>true</nillable>
       <binding>java.lang.String</binding>
-    </attribute>
-    <attribute>
-      <name>lat</name>
-      <minOccurs>1</minOccurs>
-      <maxOccurs>1</maxOccurs>
-      <nillable>false</nillable>
-      <binding>java.math.BigDecimal</binding>
-    </attribute>
-    <attribute>
-      <name>lon</name>
-      <minOccurs>1</minOccurs>
-      <maxOccurs>1</maxOccurs>
-      <nillable>false</nillable>
-      <binding>java.math.BigDecimal</binding>
+      <description>
+        <de>Echtzeit-Status der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>capacity</name>
@@ -220,6 +260,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Stellplätze</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_capacity</name>
@@ -227,13 +270,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
-    </attribute>
-    <attribute>
-      <name>realtime_free_capacity</name>
-      <minOccurs>0</minOccurs>
-      <maxOccurs>1</maxOccurs>
-      <nillable>true</nillable>
-      <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Stellplätze (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>capacity_charging</name>
@@ -241,6 +280,19 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Stellplätze mit Lademöglichkeit</de>
+      </description>
+    </attribute>
+    <attribute>
+      <name>realtime_free_capacity</name>
+      <minOccurs>0</minOccurs>
+      <maxOccurs>1</maxOccurs>
+      <nillable>true</nillable>
+      <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl freier Stellplätze (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_capacity_charging</name>
@@ -248,6 +300,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl Stellplätze mit Lademöglichkeit (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_free_capacity_charging</name>
@@ -255,6 +310,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Integer</binding>
+      <description>
+        <de>Anzahl freier Stellplätze mit Lademöglichkeit (Echtzeit)</de>
+      </description>
     </attribute>
     <attribute>
       <name>opening_hours</name>
@@ -262,6 +320,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Öffnungszeiten</de>
+      </description>
     </attribute>
     <attribute>
       <name>is_covered</name>
@@ -269,6 +330,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.Boolean</binding>
+      <description>
+        <de>Überdacht?</de>
+      </description>
     </attribute>
     <attribute>
       <name>supervision_type</name>
@@ -276,6 +340,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Art der Überwachung</de>
+      </description>
     </attribute>
     <attribute>
       <name>related_location</name>
@@ -283,6 +350,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.lang.String</binding>
+      <description>
+        <de>Ortsbezug der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>geometry</name>
@@ -290,6 +360,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>org.locationtech.jts.geom.Point</binding>
+      <description>
+        <de>Koordinate der Parkanlage</de>
+      </description>
     </attribute>
     <attribute>
       <name>created_at</name>
@@ -297,6 +370,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.sql.Timestamp</binding>
+      <description>
+        <de>Erstellungsdatum in der parkAPI</de>
+      </description>
     </attribute>
     <attribute>
       <name>modified_at</name>
@@ -304,6 +380,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.sql.Timestamp</binding>
+      <description>
+        <de>Zeitpunkt der letzten Änderung in der parkAPI</de>
+      </description>
     </attribute>
     <attribute>
       <name>static_data_updated_at</name>
@@ -311,6 +390,9 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>false</nillable>
       <binding>java.sql.Timestamp</binding>
+      <description>
+        <de>Letzter Aktualisierungszeitpunkt der statischen Daten</de>
+      </description>
     </attribute>
     <attribute>
       <name>realtime_data_updated_at</name>
@@ -318,8 +400,11 @@ WHERE purpose=&apos;ITEM&apos;
       <maxOccurs>1</maxOccurs>
       <nillable>true</nillable>
       <binding>java.sql.Timestamp</binding>
+      <description>
+        <de>Letzter Aktualisierungszeitpunkt der Echtzeitdaten</de>
+      </description>
     </attribute>
-  </attributes>  
+  </attributes>
   <overridingServiceSRS>false</overridingServiceSRS>
   <skipNumberMatched>false</skipNumberMatched>
   <circularArcPresent>false</circularArcPresent>

--- a/etc/geoserver/workspaces/MobiData-BW/park-api-db/parking_sites_item/layer.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/park-api-db/parking_sites_item/layer.xml
@@ -13,5 +13,5 @@
     <logoHeight>0</logoHeight>
   </attribution>
   <dateCreated>2024-09-26 13:13:11.131 UTC</dateCreated>
-  <dateModified>2024-09-26 13:13:39.515 UTC</dateModified>
+  <dateModified>2024-10-04 09:02:53.701 UTC</dateModified>
 </layer>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_stations_default.sld
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_stations_default.sld
@@ -16,13 +16,29 @@
                 <ogc:PropertyName>feed_id</ogc:PropertyName>
                 <ogc:Literal>stadtmobil*</ogc:Literal>
               </ogc:PropertyIsLike>
+              <ogc:PropertyIsLike wildCard="*" singleChar="#" escape="!">
+                <ogc:PropertyName>feed_id</ogc:PropertyName>
+                <ogc:Literal>teilauto*</ogc:Literal>
+              </ogc:PropertyIsLike>
               <ogc:PropertyIsEqualTo>
                 <ogc:PropertyName>feed_id</ogc:PropertyName>
                 <ogc:Literal>my-e-car</ogc:Literal>
               </ogc:PropertyIsEqualTo>
               <ogc:PropertyIsEqualTo>
                 <ogc:PropertyName>feed_id</ogc:PropertyName>
-                <ogc:Literal>teilauto_neckar-alb</ogc:Literal>
+                <ogc:Literal>oekostadt_renningen</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>feed_id</ogc:PropertyName>
+                <ogc:Literal>gruene_flotte_freiburg</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>feed_id</ogc:PropertyName>
+                <ogc:Literal>swu2go</ogc:Literal>
+              </ogc:PropertyIsEqualTo>
+              <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>feed_id</ogc:PropertyName>
+                <ogc:Literal>conficars_ulm</ogc:Literal>
               </ogc:PropertyIsEqualTo>
             </ogc:Or>
           </ogc:Filter>
@@ -52,13 +68,29 @@
                     <ogc:PropertyName>feed_id</ogc:PropertyName>
                     <ogc:Literal>stadtmobil*</ogc:Literal>
                   </ogc:PropertyIsLike>
+                  <ogc:PropertyIsLike wildCard="*" singleChar="#" escape="!">
+                    <ogc:PropertyName>feed_id</ogc:PropertyName>
+                    <ogc:Literal>teilauto*</ogc:Literal>
+                  </ogc:PropertyIsLike>
                   <ogc:PropertyIsEqualTo>
                     <ogc:PropertyName>feed_id</ogc:PropertyName>
                     <ogc:Literal>my-e-car</ogc:Literal>
                   </ogc:PropertyIsEqualTo>
                   <ogc:PropertyIsEqualTo>
                     <ogc:PropertyName>feed_id</ogc:PropertyName>
-                    <ogc:Literal>teilauto_neckar-alb</ogc:Literal>
+                    <ogc:Literal>oekostadt_renningen</ogc:Literal>
+                  </ogc:PropertyIsEqualTo>
+                  <ogc:PropertyIsEqualTo>
+                    <ogc:PropertyName>feed_id</ogc:PropertyName>
+                    <ogc:Literal>gruene_flotte_freiburg</ogc:Literal>
+                  </ogc:PropertyIsEqualTo>
+                  <ogc:PropertyIsEqualTo>
+                    <ogc:PropertyName>feed_id</ogc:PropertyName>
+                    <ogc:Literal>swu2go</ogc:Literal>
+                  </ogc:PropertyIsEqualTo>
+                  <ogc:PropertyIsEqualTo>
+                    <ogc:PropertyName>feed_id</ogc:PropertyName>
+                    <ogc:Literal>conficars_ulm</ogc:Literal>
                   </ogc:PropertyIsEqualTo>
                 </ogc:Or>
               </ogc:Not>

--- a/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_stations_default.xml
+++ b/etc/geoserver/workspaces/MobiData-BW/styles/mdbw_sharing_stations_default.xml
@@ -10,5 +10,5 @@
   </languageVersion>
   <filename>mdbw_sharing_stations_default.sld</filename>
   <dateCreated>2023-12-18 21:41:57.77 UTC</dateCreated>
-  <dateModified>2024-09-26 13:15:02.305 UTC</dateModified>
+  <dateModified>2024-10-02 11:56:06.273 UTC</dateModified>
 </style>


### PR DESCRIPTION
# GeoServer changes
## General
- updated GeoServer and its dependend plug-ins from `2.25.3` to `2.26.0`
## Parking
- renamed `parking_sites` to `parking_sites_car` accordingly to `parking_sites_bicycle` and  `parking_sites_item`
- added descriptions to the layers `parking_sites_car`, `parking_sites_bicycle` and `parking_sites_item`
- removed attributes `lat` and `lon`
## Sharing
- `MobiData-BW:mdbw_sharing_stations_default`: added current and upcoming static GBFS feeds to SLD rule `Keine Echtzeitdaten` (no realtime data)