### PR TITLE
ParkAPI 0.14.3

### DIFF
--- a/.env
+++ b/.env
@@ -113,7 +113,7 @@ PARK_API_POSTGRES_USER=park-api
 PARK_API_POSTGRES_DB=park-api
 PARK_API_POSTGRES_HOST=park-api-db
 PARK_API_CELERY_BROKER_URL=amqp://park-api-rabbitmq
-PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.14.2
+PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.14.3
 PARK_API_DB_IMAGE=postgis/postgis:15-3.4-alpine
 
 # Caddy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 - `lamassu`: upgraded [`lamassu`](https://github.com/entur/lamassu) to [2024-09-27T11-21](https://hub.docker.com/layers/entur/lamassu/2024-09-27T11-21/images/sha256-0f849baac422c1af11e2844e7dcd540a81a36414805e22c75243be2cea375a85?context=explore). This i.e. includes the `stationEntityCacheMinimumTtl` and `stationEntityCacheMaximumTtl`configuration options.
+- [ParkAPI 0.14.3 with a fix at BFRK converter](https://github.com/ParkenDD/park-api-v3/blob/9061cdeaaa16a2336e2d7a874d7331f5c2c2d2bd/CHANGELOG.md#0143)
+
 
 ## 2024-10-01
 


### PR DESCRIPTION
As the BFRK bug is rather bad because it has an influcence on other source, a release just with this bugfix