### PR TITLE
Geoserver version rollback

### DIFF
--- a/.env
+++ b/.env
@@ -91,8 +91,8 @@ IPL_GTFS_API_DOCS_PORT=4001
 GEOSERVER_PROXY_BASE_URL=http://localhost:8600/geoserver
 GEOSERVER_CSRF_WHITELIST=mobidata-bw.de
 # NOTE: When bumping GEOSERVER_IMAGE, mind to bump the GEOSERVER_PLUGIN_DYNAMIC_URLS accordingly
-GEOSERVER_IMAGE=geosolutionsit/geoserver:2.26.0
-GEOSERVER_PLUGIN_DYNAMIC_URLS=https://sourceforge.net/projects/geoserver/files/GeoServer/2.26.0/extensions/geoserver-2.26.0-vectortiles-plugin.zip https://sourceforge.net/projects/geoserver/files/GeoServer/2.26.0/extensions/geoserver-2.26.0-inspire-plugin.zip
+GEOSERVER_IMAGE=geosolutionsit/geoserver:2.25.3
+GEOSERVER_PLUGIN_DYNAMIC_URLS=https://sourceforge.net/projects/geoserver/files/GeoServer/2.25.3/extensions/geoserver-2.25.3-vectortiles-plugin.zip https://sourceforge.net/projects/geoserver/files/GeoServer/2.25.3/extensions/geoserver-2.25.3-inspire-plugin.zip
 GEOSERVER_PORT=8600
 GEOSERVER_INITIAL_MEMORY=512M
 GEOSERVER_MAXIMUM_MEMORY=4G

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - ⚠️ `gtfs-importer`: upgraded [`postgis-gtfs-importer`](https://github.com/mobidata-bw/postgis-gtfs-importer) to [`v4-2024-10-24T17.43.02-76b148e`](https://github.com/mobidata-bw/postgis-gtfs-importer/tree/76b148e) – This is a breaking change because it switches the GTFS import back (from keeping all of them) to retaining only 2 databases, similar to the old (2024-09-17) behaviour of keeping only the most recent ones.
+- GeoServer: rollback from version `2.26.0` to `2.25.3`
 
 ## 2024-10-17
 


### PR DESCRIPTION
# Changes
* GeoServer: rollback from version `2.26.0` to previsouly used version `2.25.3` due to an exception error