### PR TITLE
longer timeout for parkapi

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -720,7 +720,7 @@ services:
   park-api-flask:
     <<: *park-api-defaults
     restart: unless-stopped
-    command: ["gunicorn", "--bind", "0.0.0.0:5000", "webapp.entry_point_gunicorn:app"]
+    command: ["gunicorn", "--bind", "0.0.0.0:5000", "--timeout", "300", "webapp.entry_point_gunicorn:app"]
     ports:
       - ${PARK_API_API_PORT}:5000
     labels:


### PR DESCRIPTION
Fixes an issue where the duplicate calculation takes longer then 30 sec on slow systems