### PR TITLE
fix: add unique index to materialized view stations_with_served_route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - add Cantamen provider gruene-flotte_freiburg
 - `ingesss`: upgraded [`traefik`](https://hub.docker.com/_/traefik) to [`v3.2`](https://hub.docker.com/layers/library/traefik/v3.2/images/sha256-e8a75d3640365b5a9f2b5fbcd8c745becdceabf3b7dc4e202094fb2bf03c1d37?context=explore)
+- fix `natural order without a primary key` exception for layer transit_stations_with_served_routes
 
 ## 2024-11-05
 

--- a/etc/gtfs/postprocessing.d/31-geoserver-stations.sql
+++ b/etc/gtfs/postprocessing.d/31-geoserver-stations.sql
@@ -74,6 +74,5 @@ CREATE MATERIALIZED VIEW geoserver.stations_with_served_routes AS
 	LEFT JOIN api.stops s ON s.stop_id = t.station_id
 	;
 
-
--- todo: index?
+CREATE UNIQUE INDEX stations_with_served_routes_idx ON geoserver.stations_with_served_routes(station_id);
 -- todo: spatial index?


### PR DESCRIPTION
This PR adds a unique index on column `station_id` for materialized view `geoserver.stations_with_served_routes` (fixes #270).