### PR TITLE
x2gbfs startup dependency for lamassu

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -21,6 +21,15 @@ LAMASSU_TIER_PASSWORD=secret
 # Credentials for sharedmobility.ch
 LAMASSU_SHAREDMOBILITY_CH_AUTHORIZATION=mail@domain
 
+
+# Initial interval when for the first time and then in which interval
+# the healtcheck is executed until the container has sucessfully started.
+# For prod (when feeds are already present/lamassu polls regularly for updated feeds)
+# this can be 1s (the default configured in docker-compose.yml)
+# If no feeds exist and Lamassu's update interval is set to multiple hours,
+# set this to a value that is high enough that all feeds have been generated once.
+# X2GBFS_HEALTHCHECK_START_INTERVAL=60s
+
 # User and password from Deer
 DEER_USER=user
 DEER_PASSWORD=password

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - add Cantamen provider gruene-flotte_freiburg
 - `ingesss`: upgraded [`traefik`](https://hub.docker.com/_/traefik) to [`v3.2`](https://hub.docker.com/layers/library/traefik/v3.2/images/sha256-e8a75d3640365b5a9f2b5fbcd8c745becdceabf3b7dc4e202094fb2bf03c1d37?context=explore)
 - fix `natural order without a primary key` exception for layer transit_stations_with_served_routes
+- `lamassu` container now depends on `x2gbfs` container startup, so feeds read from file system can be created before lamassu starts. To make sure all feeds have been created, set `X2GBFS_HEALTHCHECK_START_INTERVAL` to e.g. `60s`. For production use
 
 ## 2024-11-05
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,6 +191,17 @@ services:
       - FLINKSTER_CLIENT_ID=${FLINKSTER_CLIENT_ID:?missing/empty}
       - FLINKSTER_SECRET=${FLINKSTER_SECRET:?missing/empty}
     restart: unless-stopped
+    healthcheck:
+      test: ps aux | grep -q 'x2gbfs\.x2gbfs' || exit 1
+      # If you want to wait until all feeds have been generated 
+      # before depending lamassu starts subscribing them, 
+      # configure an appropriate startup_period, e.g. 60s
+      # Otherwise, lamassu might update them only after the 
+      # update interval period has passed, which for test might
+      # last several hours.
+      start_interval: ${X2GBFS_HEALTHCHECK_START_INTERVAL:-1s}
+      start_period: 1s
+      interval: 60s
 
   lamassu:
     networks: [ipl]
@@ -233,6 +244,8 @@ services:
         redis:
           condition: service_healthy
         transformer-proxy:
+          condition: service_started
+        x2gbfs:
           condition: service_started
     restart: unless-stopped
 


### PR DESCRIPTION
This PR introduces a startup dependency, so `lamassu` waits for `x2gbfs` to be started.

Setting `X2GBFS_HEALTHCHECK_START_INTERVAL` to e.g. `60s` will wait 60s before the `x2gbfs` container becomes healthy. `lamassu` wil wait for `x2gbfs` to be healthy so that feeds can be updated already on the first update run and not only on the next, potentially several hours later (i.e. in test)