### PR TITLE
ParkAPI 0.15.3

### DIFF
--- a/.env
+++ b/.env
@@ -116,7 +116,7 @@ PARK_API_POSTGRES_USER=park-api
 PARK_API_POSTGRES_DB=park-api
 PARK_API_POSTGRES_HOST=park-api-db
 PARK_API_CELERY_BROKER_URL=amqp://park-api-rabbitmq
-PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.15.2
+PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.15.3
 PARK_API_DB_IMAGE=postgis/postgis:15-3.4-alpine
 
 # Caddy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
+2024-11-20
+
+### Changed
+
+- [ParkAPI 0.15.3 Hotfix with a required database migration](https://github.com/ParkenDD/park-api-v3/blob/3a8fb1dd526b0def3d96790045d90daa05940beb/CHANGELOG.md)
+
+
 ## 2024-11-19
 
 ### Added


### PR DESCRIPTION
Fixes the database model issue when saving realtime parking status None values. Can be used as soon as the CI ran through: https://github.com/ParkenDD/park-api-v3/actions/runs/11930240051