### PR TITLE
ParkAPI 0.16.2

### DIFF
--- a/.env
+++ b/.env
@@ -116,7 +116,7 @@ PARK_API_POSTGRES_USER=park-api
 PARK_API_POSTGRES_DB=park-api
 PARK_API_POSTGRES_HOST=park-api-db
 PARK_API_CELERY_BROKER_URL=amqp://park-api-rabbitmq
-PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.15.3
+PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.16.1
 PARK_API_DB_IMAGE=postgis/postgis:15-3.4-alpine
 
 # Caddy

--- a/.env
+++ b/.env
@@ -116,7 +116,7 @@ PARK_API_POSTGRES_USER=park-api
 PARK_API_POSTGRES_DB=park-api
 PARK_API_POSTGRES_HOST=park-api-db
 PARK_API_CELERY_BROKER_URL=amqp://park-api-rabbitmq
-PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.16.1
+PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.16.2
 PARK_API_DB_IMAGE=postgis/postgis:15-3.4-alpine
 
 # Caddy

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ Thumbs.db
 /etc/dagster/.telemetry
 /etc/dagster/logs
 /etc/park-api/config.secrets.yaml
+/etc/park-api/files/mobilithek-mobidata.crt.pem
+/etc/park-api/files/mobilithek-mobidata.key.pem
+
 /etc/ocpdb/config.secrets.yaml
 /etc/sftp
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
+## Unreleased
+
+### Changed
+
+- [ParkAPI 0.16.1](https://github.com/ParkenDD/park-api-v3/blob/908d1c4fe912ad3c7076098e20899458eb0db0c4/CHANGELOG.md#0161) with
+  - Better logging and exception handling at converters
+  - Moving access to static data to the night
+  - Extended data at Kienzler source (GeoJSON PATCH system)
+  - Better validation and therefore more valid parking sites at OpenData Swiss
+  - Fix datetime format of Karlsruhe because they changed it
+  - Code cleanup and other smaller improvements
+
+
 ## 2024-11-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
   - Better validation and therefore more valid parking sites at OpenData Swiss
   - Fix datetime format of Karlsruhe because they changed it
   - Code cleanup and other smaller improvements
+- [ParkAPI 0.16.2 with a fix for static data imports via celery heartbeat](https://github.com/ParkenDD/park-api-v3/blob/451b1f511f377efbfb4552123070be6aff754dae/CHANGELOG.md#0162)
 
 
 ## 2024-11-20


### PR DESCRIPTION
Includes ParkAPI 0.16.1 with several approvements, see changelog for details, and 0.16.2 with a celery task fix for static imports