### PR TITLE
Add free2move_stuttgart

### DIFF
--- a/.env
+++ b/.env
@@ -31,7 +31,7 @@ IPL_POSTGRES_USER=geoserver
 
 # x2gbfs variables (Note: when changing the providers, be sure to check if the image version supports them)
 X2GBFS_IMAGE=ghcr.io/mobidata-bw/x2gbfs:2024-12-18T18-46
-X2GBFS_PROVIDERS=deer,lastenvelo_fr,stadtmobil_stuttgart,stadtmobil_karlsruhe,stadtmobil_rhein-neckar,stadtmobil_suedbaden,stadtwerk_tauberfranken,zeag_energie,teilauto_neckar-alb,teilauto_biberach,oekostadt_renningen,gruene-flotte_freiburg,flinkster_carsharing,oberschwabenmobil,gmuend_bewegt
+X2GBFS_PROVIDERS=deer,lastenvelo_fr,stadtmobil_stuttgart,stadtmobil_karlsruhe,stadtmobil_rhein-neckar,stadtmobil_suedbaden,stadtwerk_tauberfranken,zeag_energie,teilauto_neckar-alb,teilauto_biberach,oekostadt_renningen,gruene-flotte_freiburg,flinkster_carsharing,oberschwabenmobil,gmuend_bewegt,free2move_stuttgart
 X2GBFS_UPDATE_INTERVAL_SECONDS=60
 
 DEER_API_URL=https://deer.fleetster.de

--- a/.env.local.example
+++ b/.env.local.example
@@ -119,3 +119,6 @@ WEBCAM_FTP_USER=user
 WEBCAM_FTP_PASSWORD=password
 # BasicAuth for Traefik: https://doc.traefik.io/traefik/middlewares/http/basicauth/#configuration-examples
 WEBCAM_BASIC_AUTH=secret
+
+# BasicAuth to access restricted GBFS feeds
+GBFS_BASIC_AUTH=user1:hashed_password1,user2:hashed_password2

--- a/.env.local.example
+++ b/.env.local.example
@@ -43,6 +43,10 @@ DEER_PASSWORD=password
 FLINKSTER_CLIENT_ID=client_id
 FLINKSTER_SECRET=secret
 
+# Credentials for Free2move
+X2GBFS_FREE2MOVE_USER=user
+X2GBFS_FREE2MOVE_PASSWORD=secret
+
 # Url to the cantamen IXSI service. Note: this service is IP restricted
 CANTAMEN_IXSI_API_URL=http://example.org
 #Timeout for cantamen IXSI websocket connection in seconds

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,10 @@ init: etc/sftp/users.conf etc/sftp/ssh_host_ed25519_key etc/sftp/ssh_host_rsa_ke
 	mkdir -p var/ocpdb/temp
 	mkdir -p var/park-api/logs
 	mkdir -p var/park-api/temp
+	mkdir -p var/gbfs/temp
 	mkdir -p var/www/datasets/traffic/incidents-bw
+	mkdir -p var/caddy/
+	touch -a var/caddy/usersfile
 
 # Container management
 # --------------------

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,6 @@ init: etc/sftp/users.conf etc/sftp/ssh_host_ed25519_key etc/sftp/ssh_host_rsa_ke
 	mkdir -p var/park-api/temp
 	mkdir -p var/gbfs/temp
 	mkdir -p var/www/datasets/traffic/incidents-bw
-	mkdir -p var/caddy/
-	touch -a var/caddy/usersfile
 
 # Container management
 # --------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,7 +177,7 @@ services:
       - "traefik.http.middlewares.caddy-webcam.basicauth.users=${WEBCAM_BASIC_AUTH:?missing/empty}"
       - "traefik.http.routers.caddy-gbfs.rule=PathPrefix(`/gbfs`)"
       - "traefik.http.routers.caddy-gbfs.middlewares=caddy-gbfs"
-      - "traefik.http.middlewares.caddy-gbfs.basicauth.usersfile=./var/caddy/usersfile"
+      - "traefik.http.middlewares.caddy-gbfs.basicauth.users=${GBFS_BASIC_AUTH:?missing/empty}"
 
   # This service requests non-standard sharing provider APIs and generates
   # a gbfs feed intended for local import into Lamassu. The volume needs to be

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,8 @@ services:
       - ./var/www/datasets:/var/www/datasets:ro
       # webcam data (served on :80, password-protected by the `ingress` service)
       - ./var/webcam:/var/www/webcam:ro
+      # non-public gbfs feeds
+      - ./var/gbfs/feeds/free2move_stuttgart:/var/www/gbfs/free2move_stuttgart:ro
       # well-known URIs: security.txt, favicon.ico, etc. (served on :80)
       - ./etc/well-known:/var/www/well-known:ro
       # GoAccess access statistics reports (served on :81)
@@ -173,6 +175,9 @@ services:
       - "traefik.http.services.caddy.loadbalancer.server.port=80"
       - "traefik.http.routers.caddy-webcam.middlewares=caddy-webcam"
       - "traefik.http.middlewares.caddy-webcam.basicauth.users=${WEBCAM_BASIC_AUTH:?missing/empty}"
+      - "traefik.http.routers.caddy-gbfs.rule=PathPrefix(`/gbfs`)"
+      - "traefik.http.routers.caddy-gbfs.middlewares=caddy-gbfs"
+      - "traefik.http.middlewares.caddy-gbfs.basicauth.usersfile=./var/caddy/usersfile"
 
   # This service requests non-standard sharing provider APIs and generates
   # a gbfs feed intended for local import into Lamassu. The volume needs to be
@@ -182,6 +187,7 @@ services:
     image: ${X2GBFS_IMAGE}
     volumes:
       - ./var/gbfs/feeds:/app/out/
+      - ./var/gbfs/temp:/app/temp/
     command: -p ${X2GBFS_PROVIDERS:?missing/empty} -b file:///var/gbfs/feeds -i ${X2GBFS_UPDATE_INTERVAL_SECONDS:?missing/empty}
     environment:
       - DEER_API_URL
@@ -192,6 +198,9 @@ services:
       - MOQO_API_TOKEN=${MOQO_API_TOKEN:?missing/empty}
       - FLINKSTER_CLIENT_ID=${FLINKSTER_CLIENT_ID:?missing/empty}
       - FLINKSTER_SECRET=${FLINKSTER_SECRET:?missing/empty}
+      - FREE2MOVE_USER=${X2GBFS_FREE2MOVE_USER:?missing/empty}
+      - FREE2MOVE_PASSWORD=${X2GBFS_FREE2MOVE_PASSWORD:?missing/empty}
+      - CACHE_DIR=/app/temp
     restart: unless-stopped
     healthcheck:
       test: ps aux | grep -q 'x2gbfs\.x2gbfs' || exit 1

--- a/etc/caddy/Caddyfile
+++ b/etc/caddy/Caddyfile
@@ -18,6 +18,11 @@ http://:80 {
     file_server browse
   }
 
+  # private gbfs feeds. Access restricted via traefik
+  handle_path /gbfs/* {
+    root * /var/www/gbfs
+  }
+
   # well-known URIs (security.txt, favicon.ico, etc.)
   handle /robots.txt {
     root * /var/www/well-known


### PR DESCRIPTION
This PR

* configures `free2move` credential handling and enables x2gbfs feed generation
* publish private `free2move_stuttgart` feed via caddy as basic auth protected path `gbfs/free2move_stuttgart/`
* prepare basicauth configuration via new ENV VAR GBFS_BASIC_AUTH
