### PR TITLE
chore(deps): bump ipl-dagster to 2025-01-28t15-57

### DIFF
--- a/.env
+++ b/.env
@@ -39,9 +39,9 @@ VOI_API_URL=https://lsd.raumobil.net/Broker/grid?platform=mobidata-bw&source=voi
 
 # dagster variables
 DAGSTER_POSTGRES_IMAGE=postgres:15.10-bullseye
-DAGSTER_PIPELINE_IMAGE=ghcr.io/mobidata-bw/dagster-pipeline:2024-12-03t09-35
-DAGSTER_DAGIT_IMAGE=ghcr.io/mobidata-bw/dagster-dagit:2024-12-03t09-35
-DAGSTER_DAEMON_IMAGE=ghcr.io/mobidata-bw/dagster-daemon:2024-12-03t09-35
+DAGSTER_PIPELINE_IMAGE=ghcr.io/mobidata-bw/dagster-pipeline:2025-01-28T15-57
+DAGSTER_DAGIT_IMAGE=ghcr.io/mobidata-bw/dagster-dagit:2025-01-28T15-57
+DAGSTER_DAEMON_IMAGE=ghcr.io/mobidata-bw/dagster-daemon:2025-01-28T15-57
 DAGSTER_POSTGRES_USER=postgres_user
 DAGSTER_POSTGRES_DB=postgres_db
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
+## Next release
+
+## Changed
+
+- `dagster-pipeline`/`dagster-daemon`/`dagster-dagit`: upgrade to [`2025-01-28t15-57`](https://github.com/mobidata-bw/ipl-dagster-pipeline/commit/6b1448ce788b6997df8c1db90dc9369da4bb0001), fixes #306 and the root cause of a WFS2.0.0 issue caused by missing primary keys.
+
 ## 2025-01-28
 
 ### Added


### PR DESCRIPTION
This PR bumps ipl-dagster to 2025-01-28t15-57, which fixes #306 and the root cause of a WFS2.0.0 issue caused by missing primary keys.

