### PR TITLE
ParkAPI 0.18.1

### DIFF
--- a/.env
+++ b/.env
@@ -119,7 +119,7 @@ PARK_API_POSTGRES_USER=park-api
 PARK_API_POSTGRES_DB=park-api
 PARK_API_POSTGRES_HOST=park-api-db
 PARK_API_CELERY_BROKER_URL=amqp://rabbitmq/park-api
-PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.18.0
+PARK_API_IMAGE=ghcr.io/parkendd/park-api-v3:0.18.1
 PARK_API_DB_IMAGE=postgis/postgis:15-3.4-alpine
 
 # Caddy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
+## Unreleased
+
+### Changed
+
+- [ParkAPI: Hotfix ParkAPI OpeningTime output for ParkAPI v1](https://github.com/ParkenDD/park-api-v3/blob/dca14b8195cb015f8e5076bce79d46861445c604/CHANGELOG.md#0181)
+
+
 ## 2025-02-04
 
 ### Added


### PR DESCRIPTION
Fixes an issue with ParkAPI v1 output. Please wait for https://github.com/ParkenDD/park-api-v3/actions/runs/13133869870 before merging / deploying