### PR TITLE
upgrade gtfs-importer to v5

### DIFF
--- a/.env
+++ b/.env
@@ -54,7 +54,7 @@ IPL_GTFS_DB_POSTGRES_DB=gtfs_importer
 IPL_GTFS_DB_POSTGRES_DB_PREFIX=gtfs
 
 # gtfs-importer variables
-IPL_GTFS_IMPORTER_IMAGE=ghcr.io/mobidata-bw/postgis-gtfs-importer:v4-2024-10-24T17.43.02-76b148e
+IPL_GTFS_IMPORTER_IMAGE=ghcr.io/mobidata-bw/postgis-gtfs-importer:v5-2025-02-19T00.49.01-20c1b09
 IPL_GTFS_IMPORTER_GTFS_DOWNLOAD_URL=https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/bwgesamt.zip
 IPL_GTFS_IMPORTER_GTFS_DOWNLOAD_USER_AGENT="IPL (MobiData-BW)"
 # This assumes, that the ipl platform is started in a directory `ipl` which's name becomes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
+## [Unreleased]
+
+### Changed
+
+- ⚠️ `gtfs-importer`: upgraded [`postgis-gtfs-importer`](https://github.com/mobidata-bw/postgis-gtfs-importer) to [`v5-2025-02-19T00.49.01-20c1b09`](https://github.com/mobidata-bw/postgis-gtfs-importer/tree/20c1b09) – This is a breaking change because future GTFS imports won't work without a manual migration step. Please run `docker compose --env-file .env --env-file .env.local exec gtfs-db /bin/sh -c 'env PGUSER="$POSTGRES_USER" PGPASSWORD="$POSTGRES_PASSWORD" psql gtfs_importer -1 -c "CREATE TABLE IF NOT EXISTS latest_successful_imports (db_name TEXT PRIMARY KEY, imported_at INTEGER NOT NULL, feed_digest TEXT NOT NULL); INSERT INTO latest_successful_imports (db_name, imported_at, feed_digest) SELECT db_name, split_part(db_name, '\''_'\'', 2)::integer AS imported_at, split_part(db_name, '\''_'\'', 3) AS feed_digest FROM latest_import"'` to adapt the `gtfs_importer` database to the new way `postgis-gtfs-importer` keeps track of the imports (a table `latest_successful_imports`).
+
 ## 2025-02-12
 
 ### Changed


### PR DESCRIPTION
Fixes https://github.com/mobidata-bw/postgis-gtfs-importer/issues/11.

This change requires a manual migration to the new bookkeeping table (format). @hbruch @ThorstenFroehlinghaus Can you make sense of the `CHANGELOG.md` entry? Does it help you?

---

closes #293 
fixes #323