### PR TITLE
chore: bump lamassu, x2gbfs, ipl-dagster-pipeline

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@ TZ=Europe/Berlin
 TRANSFORMER_PROXY_IMAGE=ghcr.io/mobidata-bw/ipl-proxy:2025-03-03T07-10
 TRANSFORMER_PROXY_PORT=8400
 
-LAMASSU_IMAGE=entur/lamassu:2024-12-17T19-37
+LAMASSU_IMAGE=entur/lamassu:2025-03-01T04-51
 LAMASSU_PORT=8500
 LAMASSU_ADMIN_PORT=9002
 LAMASSU_BASE_URL=http://localhost:8080/sharing
@@ -30,18 +30,19 @@ IPL_POSTGRES_DB=geoserver
 IPL_POSTGRES_USER=geoserver
 
 # x2gbfs variables (Note: when changing the providers, be sure to check if the image version supports them)
-X2GBFS_IMAGE=ghcr.io/mobidata-bw/x2gbfs:2025-03-03T13-17
+X2GBFS_IMAGE=ghcr.io/mobidata-bw/x2gbfs:2025-03-03t13-17
 X2GBFS_PROVIDERS=deer,lastenvelo_fr,stadtmobil_stuttgart,stadtmobil_karlsruhe,stadtmobil_rhein-neckar,naturenergie_sharing,stadtwerk_tauberfranken,zeag_energie,teilauto_neckar-alb,teilauto_biberach,teilauto_schwaebisch_hall,oekostadt_renningen,gruene-flotte_freiburg,flinkster_carsharing,oberschwabenmobil,gmuend_bewegt,free2move_stuttgart
 X2GBFS_UPDATE_INTERVAL_SECONDS=60
+
 
 DEER_API_URL=https://deer.fleetster.de
 VOI_API_URL=https://lsd.raumobil.net/Broker/grid?platform=mobidata-bw&source=voi&type=eScooter&hashes=u0ty,u0tz
 
 # dagster variables
 DAGSTER_POSTGRES_IMAGE=postgres:15.10-bullseye
-DAGSTER_PIPELINE_IMAGE=ghcr.io/mobidata-bw/dagster-pipeline:2025-01-28T15-57
-DAGSTER_DAGIT_IMAGE=ghcr.io/mobidata-bw/dagster-dagit:2025-01-28T15-57
-DAGSTER_DAEMON_IMAGE=ghcr.io/mobidata-bw/dagster-daemon:2025-01-28T15-57
+DAGSTER_PIPELINE_IMAGE=ghcr.io/mobidata-bw/dagster-pipeline:2025-03-03t11-50
+DAGSTER_DAGIT_IMAGE=ghcr.io/mobidata-bw/dagster-dagit:2025-03-03t11-50
+DAGSTER_DAEMON_IMAGE=ghcr.io/mobidata-bw/dagster-daemon:2025-03-03t11-50
 DAGSTER_POSTGRES_USER=postgres_user
 DAGSTER_POSTGRES_DB=postgres_db
 

--- a/.env.local.example
+++ b/.env.local.example
@@ -39,6 +39,10 @@ X2GBFS_FREE2MOVE_BASE_URL=url
 X2GBFS_FREE2MOVE_USER=user
 X2GBFS_FREE2MOVE_PASSWORD=secret
 
+# Custom base url under which (basic auth secured) feeds 
+# are published directly, not served via lamassu
+X2GBFS_CUSTOM_BASE_URL=url
+
 # Url to the cantamen IXSI service. Note: this service is IP restricted
 CANTAMEN_IXSI_API_URL=http://example.org
 #Timeout for cantamen IXSI websocket connection in seconds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
+
 ## [Unreleased]
 
 ### Changed
 
 - GeoServer: fix image name in `.env` (`geoserver` -> `ipl-geoserver`), pulling the image should now be possible again
 - GeoServer: hard-code platform `linux/amd64` because there are currently no other platforms supported
+- `lamassu`: upgraded [`lamassu`](https://github.com/entur/lamassu) to [2025-03-01T04-51](https://hub.docker.com/layers/entur/lamassu/2025-03-01T04-51/images/sha256-742f539b77ded7173da2e5b66db922e8cd657d344531417de7e86cd5591fd7d5). This i.e. includes an internal refactoring which reduces redis memory usage and improves graphql performance. For details see https://github.com/entur/lamassu/blob/master/Changelog.md?plain=1#L9C64-L17
+- [dagster-pipeline/dagster-daemon/dagster-dagit: upgrade to `2025-03-03t11-50`](https://github.com/mobidata-bw/ipl-dagster-pipeline/blob/main/CHANGELOG.md?plain=1#L6-L10)
+- [x2gbfs 2025-03-03T13-17:](https://github.com/mobidata-bw/x2gbfs/blob/main/CHANGELOG.md#2024-03-03)
+  - fix: update `deer` pricing plans
+  - round vehicle and station coords to at most six decimal places
+  - some x2gbfs deployment related changes, see x2gbfs [CHANGELOG]((https://github.com/mobidata-bw/x2gbfs/blob/main/CHANGELOG.md#2024-03-03)) for these
+
 
 ## 2025-02-25
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,7 +175,7 @@ services:
     volumes:
       - ./var/gbfs/feeds:/app/out/
       - ./var/gbfs/temp:/app/temp/
-    command: -p ${X2GBFS_PROVIDERS:?missing/empty} -b file:///var/gbfs/feeds -i ${X2GBFS_UPDATE_INTERVAL_SECONDS:?missing/empty}
+    command: -p ${X2GBFS_PROVIDERS:?missing/empty} -b file:///var/gbfs/feeds -c ${X2GBFS_CUSTOM_BASE_URL?missing/empty} -i ${X2GBFS_UPDATE_INTERVAL_SECONDS:?missing/empty}
     environment:
       - DEER_API_URL
       - DEER_USER=${DEER_USER:?missing/empty}


### PR DESCRIPTION
This PR contains the following changes:

- `lamassu`: upgraded [`lamassu`](https://github.com/entur/lamassu) to [2025-03-01T04-51](https://hub.docker.com/layers/entur/lamassu/2025-03-01T04-51/images/sha256-742f539b77ded7173da2e5b66db922e8cd657d344531417de7e86cd5591fd7d5). This i.e. includes an internal refactoring which reduces redis memory usage and improves graphql performance. For details see https://github.com/entur/lamassu/blob/master/Changelog.md?plain=1#L9C64-L17
- [dagster-pipeline/dagster-daemon/dagster-dagit: upgrade to `2025-03-03t11-50`](https://github.com/mobidata-bw/ipl-dagster-pipeline/blob/main/CHANGELOG.md?plain=1#L6-L10)
- [x2gbfs 2025-03-03T13-17:](https://github.com/mobidata-bw/x2gbfs/blob/main/CHANGELOG.md#2024-03-03)
  - fix: update `deer` pricing plans
  - round vehicle and station coords to at most six decimal places
  - some x2gbfs deployment related changes, see x2gbfs [CHANGELOG](https://github.com/mobidata-bw/x2gbfs/blob/main/CHANGELOG.md#2024-03-03) for these