### PR TITLE
use sh as park api shell after switch to alpine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,5 +156,5 @@ park-api-upgrade:
 
 .PHONY: park-api-shell
 park-api-shell:
-	$(DOCKER_COMPOSE) exec park-api-flask /bin/bash
+	$(DOCKER_COMPOSE) exec park-api-flask /bin/sh
 


### PR DESCRIPTION
Fixes `make park-api-shell` by using a shell (`sh`) which is available at the alpine image.