### PR TITLE
fix: re-enable WebMercatorQuad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - remove deactivated GBFS feed `dott_st_gallen`
+- GeoServer: add MatrixTileSet WebMercatorQuad for vector tile layer roadworks
 
 ## 2025-03-11
 

--- a/etc/geoserver/gwc-layers/LayerInfoImpl--2f417ac5_18e2df033ce_-7ff0.xml
+++ b/etc/geoserver/gwc-layers/LayerInfoImpl--2f417ac5_18e2df033ce_-7ff0.xml
@@ -10,14 +10,20 @@
     <gridSubset>
       <gridSetName>WebMercatorQuadx2</gridSetName>
       <minCachedLevel>6</minCachedLevel>
+      <maxCachedLevel>16</maxCachedLevel>
+     </gridSubset>
+     <gridSubset>
+       <gridSetName>WebMercatorQuad</gridSetName>
+       <minCachedLevel>6</minCachedLevel>
+       <maxCachedLevel>16</maxCachedLevel>
     </gridSubset>
   </gridSubsets>
   <metaWidthHeight>
     <int>4</int>
     <int>4</int>
   </metaWidthHeight>
-  <expireCache>86400</expireCache>
-  <expireClients>86400</expireClients>
+  <expireCache>300</expireCache>
+  <expireClients>300</expireClients>
   <parameterFilters>
     <styleParameterFilter>
       <key>STYLES</key>


### PR DESCRIPTION
This PR re-enables MatrixTileSet WebMercatorQuad and limits caching to 300s as roadworks may change during the day.