### PR TITLE
set max-tolerated-overdue-seconds=300

### DIFF
--- a/etc/lamassu/application.properties
+++ b/etc/lamassu/application.properties
@@ -61,6 +61,8 @@ org.entur.lamassu.stationEntityCacheMinimumTtl=${LAMASSU_FEED_CACHE_MINIMUM_INTE
 org.entur.lamassu.stationEntityCacheMaximumTtl=${LAMASSU_FEED_CACHE_MINIMUM_INTERVAL_IN_S:21600}
 org.entur.lamassu.vehicleEntityCacheMinimumTtl=${LAMASSU_FEED_CACHE_MINIMUM_INTERVAL_IN_S:21600}
 org.entur.lamassu.vehicleEntityCacheMaximumTtl=${LAMASSU_FEED_CACHE_MINIMUM_INTERVAL_IN_S:21600}
+# Parameter for app.lamassu.gbfs.filesoverdue metric
+org.entur.lamassu.max-tolerated-overdue-seconds=300
 
 
 ## Host / IP of internal load balancer for internal endpoints (as seen from docker-compose containers)


### PR DESCRIPTION
extend delay for app.lamassu.gbfs.filesoverdue metric