### PR TITLE
gtfs-importer: allow manually resolving a domain name, default to harmless mapping

### DIFF
--- a/.env
+++ b/.env
@@ -55,6 +55,9 @@ IPL_GTFS_DB_POSTGRES_DB_PREFIX=gtfs
 # gtfs-importer variables
 IPL_GTFS_IMPORTER_IMAGE=ghcr.io/mobidata-bw/postgis-gtfs-importer:v5-2025-02-28T14.45.19-2a4e7d2
 IPL_GTFS_IMPORTER_GTFS_DOWNLOAD_URL=https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/bwgesamt.zip
+# To make the GTFS import work within NVBW's IT infrastructure, we must manually resolve the GTFS server's domain.
+# Here however, in the default configuration, we set a harmless entry (an RFC 6761 special-use domain) that shouldn't interfere with the IPL operation.
+IPL_GTFS_IMPORTER_EXTRA_HOST="random.alt=127.0.0.1"
 IPL_GTFS_IMPORTER_GTFS_DOWNLOAD_USER_AGENT="IPL (MobiData-BW)"
 # This assumes, that the ipl platform is started in a directory `ipl` which's name becomes
 # the docker project name and is prefixed to the `ipl` network defined in docker-compose.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
+## [Unreleased]
+
+### Changed
+
+- `gtfs-importer`: Allow manually resolving a domain name.
+  - To make the GTFS import work with the *MobiData-BW IPL deployment*, we manually resolve the GTFS server's domain.
+  - However, the IPL default configuration resolves `random.alt` (an RFC 6761 special-use domain) to `127.0.0.1`, so it shouldn't interfere with IPL setups elsewhere.
+
 ## 2025-05-06
 
 ### Changed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -643,6 +643,8 @@ services:
       - ./etc/gtfs:/etc/gtfs
       # mount modified download script
       - ./etc/gtfs/download.sh:/importer/download.sh
+    extra_hosts:
+      - "${IPL_GTFS_IMPORTER_EXTRA_HOST:?missing/empty}"
     environment:
       PGHOST: gtfs-db
       PGPORT: 5432


### PR DESCRIPTION
We'll set the domain mapping necessary for the *MobiData-BW deployment* in `.env.local` via Ansible.

fixes https://github.com/mobidata-bw/ipl-planning/issues/22
part of https://github.com/mobidata-bw/ipl-planning/issues/12