### PR TITLE
Gtfs importer extra host 2

### DIFF
--- a/.env
+++ b/.env
@@ -57,7 +57,8 @@ IPL_GTFS_IMPORTER_IMAGE=ghcr.io/mobidata-bw/postgis-gtfs-importer:v5-2025-02-28T
 IPL_GTFS_IMPORTER_GTFS_DOWNLOAD_URL=https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/bwgesamt.zip
 # To make the GTFS import work within NVBW's IT infrastructure, we must manually resolve the GTFS server's domain.
 # Here however, in the default configuration, we set a harmless entry (an RFC 6761 special-use domain) that shouldn't interfere with the IPL operation.
-IPL_GTFS_IMPORTER_EXTRA_HOST="random.alt=127.0.0.1"
+IPL_GTFS_IMPORTER_EXTRA_HOST_HOSTNAME=random.alt
+IPL_GTFS_IMPORTER_EXTRA_HOST_IP="127.0.0.1"
 IPL_GTFS_IMPORTER_GTFS_DOWNLOAD_USER_AGENT="IPL (MobiData-BW)"
 # This assumes, that the ipl platform is started in a directory `ipl` which's name becomes
 # the docker project name and is prefixed to the `ipl` network defined in docker-compose.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- `gtfs-importer`: Allow manually resolving a domain name using `$IPL_GTFS_IMPORTER_EXTRA_HOST_HOSTNAME` & `$IPL_GTFS_IMPORTER_EXTRA_HOST_IP`.
+- GTFS import: Allow manually resolving a domain name using `$IPL_GTFS_IMPORTER_EXTRA_HOST_HOSTNAME` & `$IPL_GTFS_IMPORTER_EXTRA_HOST_IP`.
+  - This applies to the Compose services `gtfs-importer` and `dagster-pipeline`.
   - To make the GTFS import work with the *MobiData-BW IPL deployment*, we manually resolve the GTFS server's domain.
   - However, the IPL default configuration resolves `random.alt` (an RFC 6761 special-use domain) to `127.0.0.1`, so it shouldn't interfere with IPL setups elsewhere.
 - GeoServer: reduce maxZoom levels for vector tile caching and add description to some layers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- `gtfs-importer`: Allow manually resolving a domain name.
+- `gtfs-importer`: Allow manually resolving a domain name using `$IPL_GTFS_IMPORTER_EXTRA_HOST_HOSTNAME` & `$IPL_GTFS_IMPORTER_EXTRA_HOST_IP`.
   - To make the GTFS import work with the *MobiData-BW IPL deployment*, we manually resolve the GTFS server's domain.
   - However, the IPL default configuration resolves `random.alt` (an RFC 6761 special-use domain) to `127.0.0.1`, so it shouldn't interfere with IPL setups elsewhere.
 - GeoServer: reduce maxZoom levels for vector tile caching and add description to some layers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -409,6 +409,8 @@ services:
       - IPL_GTFS_DB_POSTGRES_DB
       - IPL_GTFS_DB_POSTGRES_DB_PREFIX
       - IPL_GTFS_IMPORTER_SCHEMA=${IPL_GTFS_IMPORTER_SCHEMA:?missing/empty}
+      - IPL_GTFS_IMPORTER_EXTRA_HOST_HOSTNAME
+      - IPL_GTFS_IMPORTER_EXTRA_HOST_IP
       - IPL_GTFS_DB_POSTGREST_USER
       - IPL_GTFS_DB_POSTGREST_PASSWORD
       # Required to mount volumes for docker-in-docker executions

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -644,7 +644,7 @@ services:
       # mount modified download script
       - ./etc/gtfs/download.sh:/importer/download.sh
     extra_hosts:
-      - "${IPL_GTFS_IMPORTER_EXTRA_HOST:?missing/empty}"
+      - "${IPL_GTFS_IMPORTER_EXTRA_HOST_HOSTNAME:?missing/empty}=${IPL_GTFS_IMPORTER_EXTRA_HOST_IP:?missing/empty}"
     environment:
       PGHOST: gtfs-db
       PGPORT: 5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -505,6 +505,9 @@ services:
   gtfs-db:
     networks: [ipl]
     image: ${IPL_GTFS_DB_IMAGE}
+    # mobidata-bw/postgis-with-pg-plan-filter currently only supports linux/amd64
+    # see https://github.com/mobidata-bw/postgis-with-pg-plan-filter/issues/1
+    platform: linux/amd64
     volumes:
       - ./var/gtfs/gtfs-db:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
This PR is a follow-up of https://github.com/mobidata-bw/ipl-orchestration/pull/369.

Because we not only need to configure the `extra_hosts` entry for the `gtfs_importer` Compose service (for use via `make import-new-gtfs`) but also in [Dagster's `gtfs` asset, which runs a *non-Compose* container](https://github.com/mobidata-bw/ipl-dagster-pipeline/blob/d9e295224ce577aa2e577ebecb335b2efc5baaa4/pipeline/assets/gtfs.py#L16-L53), and because [`docker-py`'s `containers.run()`](https://docker-py.readthedocs.io/en/stable/containers.html) `extra_hosts` option only accepts a Python dict, and because I didn't want to *parse* `$IPL_GTFS_IMPORTER_EXTRA_HOST` into hostname & IP, I opted for two variables `$IPL_GTFS_IMPORTER_EXTRA_HOST_HOSTNAME` and `$IPL_GTFS_IMPORTER_EXTRA_HOST_IP`. 🙄

There will be another follow-up PR in the `ipl-dagster-pipeline` repo.