### PR TITLE
feat: add herrenberg cargo bike feeds

### DIFF
--- a/.env
+++ b/.env
@@ -31,7 +31,7 @@ IPL_POSTGRES_USER=geoserver
 
 # x2gbfs variables (Note: when changing the providers, be sure to check if the image version supports them)
 X2GBFS_IMAGE=ghcr.io/mobidata-bw/x2gbfs:2025-05-06T06-53
-X2GBFS_PROVIDERS=deer,lastenvelo_fr,stadtmobil_stuttgart,stadtmobil_karlsruhe,stadtmobil_rhein-neckar,naturenergie_sharing,stadtwerk_tauberfranken,teilauto_neckar-alb,teilauto_biberach,teilauto_schwaebisch_hall,oekostadt_renningen,gruene-flotte_freiburg,flinkster_carsharing,oberschwabenmobil,gmuend_bewegt,coono,free2move_stuttgart
+X2GBFS_PROVIDERS=deer,lastenvelo_fr,stadtmobil_stuttgart,stadtmobil_karlsruhe,stadtmobil_rhein-neckar,naturenergie_sharing,stadtwerk_tauberfranken,teilauto_neckar-alb,teilauto_biberach,teilauto_schwaebisch_hall,oekostadt_renningen,gruene-flotte_freiburg,flinkster_carsharing,oberschwabenmobil,gmuend_bewegt,coono,free2move_stuttgart,herrenberg_alf,herrenberg_fare,herrenberg_guelf,herrenberg_stadtrad
 X2GBFS_UPDATE_INTERVAL_SECONDS=60
 
 DEER_API_URL=https://deer.fleetster.de

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
-- add feed `lime_stuttgart`
+- Lamassu:
+  - add feed `lime_stuttgart`, `herrenberg_alf`, `herrenberg_fare`, `herrenberg_guelf`, `herrenberg_stadtrad`
 - GeoServer:
 	- change default style for `MobiData-BW:charge_points` to `mdbw_charge_points_dynamic`
    	- change bounding boxes and add attribute names for gtfs layers for `MobiData-BW:transit_shapes_with_routes`, `MobiData-BW:transit_stations_with_served_routes` and `MobiData-BW:transit_stops`

--- a/etc/lamassu/feedproviders.yml
+++ b/etc/lamassu/feedproviders.yml
@@ -239,6 +239,31 @@ lamassu:
       # Note: doot feeds are accessed via proxy, using http instead of https
       url: "http://gbfs.api.ridedott.com/public/v2/mainz/gbfs.json"
       language: en
+    ## Herrenberg cargo bikes
+    - systemId: herrenberg_alf
+      operatorId: HBG:Operator:alf
+      operatorName: ALF - das Affst\u00e4tter Lastenfahrrad
+      codespace: HBG
+      url: "file:///var/gbfs/feeds/herrenberg_alf/gbfs.json"
+      language: de
+    - systemId: herrenberg_fare
+      operatorId: HBG:Operator:fare
+      operatorName: FaRe - das Bananologen Lastenrad
+      codespace: HBG
+      url: "file:///var/gbfs/feeds/herrenberg_fare/gbfs.json"
+      language: de
+    - systemId: herrenberg_guelf
+      operatorId: HBG:Operator:guelf
+      operatorName: G\u00fclf - das G\u00fcltsteiner Lastenrad
+      codespace: HBG
+      url: "file:///var/gbfs/feeds/herrenberg_guelf/gbfs.json"
+      language: de
+    - systemId: herrenberg_stadtrad
+      operatorId: HBG:Operator:stadtrad
+      operatorName: stadtRad - das stadtnavi Lastenrad
+      codespace: HBG
+      url: "file:///var/gbfs/feeds/herrenberg_stadtrad/gbfs.json"
+      language: de
     ## Lime DE
     - systemId: lime_hamburg
       operatorId: LME:Operator:lime


### PR DESCRIPTION
This PR adds cargo bike feeds for rental services in the city of Herrenberg.