### PR TITLE
GTFS services: upgrade gtfs-importer, gtfs-api & gtfs-db

### DIFF
--- a/.env
+++ b/.env
@@ -49,7 +49,7 @@ DAGSTER_POSTGRES_DB=postgres_db
 
 # gtfs-db variables
 # built from https://github.com/mobidata-bw/postgis-with-pg-plan-filter
-IPL_GTFS_DB_IMAGE=ghcr.io/mobidata-bw/postgis-with-pg-plan-filter:2024-05-15T15.25.26-d44ab82
+IPL_GTFS_DB_IMAGE=ghcr.io/mobidata-bw/postgis-with-pg-plan-filter:2026-04-08T15.38.33-3b74475
 IPL_GTFS_DB_POSTGRES_HOST=gtfs-db
 IPL_GTFS_DB_POSTGRES_USER=postgres
 IPL_GTFS_DB_POSTGRES_DB=gtfs_importer

--- a/.env
+++ b/.env
@@ -56,7 +56,7 @@ IPL_GTFS_DB_POSTGRES_DB=gtfs_importer
 IPL_GTFS_DB_POSTGRES_DB_PREFIX=gtfs
 
 # gtfs-importer variables
-IPL_GTFS_IMPORTER_IMAGE=ghcr.io/mobidata-bw/postgis-gtfs-importer:v5-2025-11-04t11.28.22-494c209
+IPL_GTFS_IMPORTER_IMAGE=ghcr.io/mobidata-bw/postgis-gtfs-importer:v5-2026-03-09T13.34.46-696778a
 # Note: The MobiData-BW IPL instances (api.mobidata-bw.de a.k.a. production, test, dev) use a different internal GTFS feed with greater coverage. It is configured using `.env.local` via mobidata-bw/ipl-ansible.
 IPL_GTFS_IMPORTER_GTFS_DOWNLOAD_URL=https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/bwgesamt.zip
 # To make the GTFS import work within NVBW's IT infrastructure, we must manually resolve the GTFS server's domain.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - `ingess`: upgrade [`traefik`](https://hub.docker.com/_/traefik) to [`v3.6.13`](https://github.com/traefik/traefik/blob/v3.6.13/CHANGELOG.md) ([`v3.6.12` release](https://github.com/traefik/traefik/blob/v3.6.12/CHANGELOG.md))
 - `gtfs-api`: upgrade [`postgrest/postgrest`](https://hub.docker.com/r/postgrest/postgrest) to [`v14.8`](https://github.com/PostgREST/postgrest/releases/tag/v14.8)
+- `gtfs-importer`: upgrade [`postgis-gtfs-importer`](https://github.com/mobidata-bw/postgis-gtfs-importer) to [`v5-2026-03-09T13.34.46-696778a`](https://github.com/mobidata-bw/postgis-gtfs-importer/tree/696778a)
 - `sftp`: upgrade [`atmoz/sftp`](https://hub.docker.com/r/atmoz/sftp) to the latest ([`alpine`](https://hub.docker.com/layers/atmoz/sftp/alpine/images/sha256-56483e4d6678cbca5afccb1a6c525d95ba8f65dfb69063954a73317eda911579))
 - `pgbouncer`: upgrade to [`ghcr.io/mobidata-bw/pgbouncer:2026-01-03T04.37.53_afa4959`](https://github.com/mobidata-bw/bitnami-pgbouncer-image/tree/edae5705da14f318b39ee2c0517a951b18bd77a7), which is just a rebuild based on a new [`docker.io/bitnami/minideb:bookworm` base image](https://github.com/bitnami/containers/blob/afa495962f3fd58d0bbe4b02c9a70cb5dc66d0a2/bitnami/pgbouncer/1/debian-12/Dockerfile#L4C6-L4C40).
 
@@ -387,6 +388,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - [x2gbfs 2025-06-24T05-53](https://github.com/mobidata-bw/x2gbfs/blob/main/CHANGELOG.md#2025-06-23)
 - [ParkAPI 0.25.0 with Freiburg P+R Converters](https://github.com/ParkenDD/park-api-v3/blob/596044d678d34e0a648ed4d8c20a197ba3444912/CHANGELOG.md#0250)
+
 
 ## 2025-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `ingess`: upgrade [`traefik`](https://hub.docker.com/_/traefik) to [`v3.6.13`](https://github.com/traefik/traefik/blob/v3.6.13/CHANGELOG.md) ([`v3.6.12` release](https://github.com/traefik/traefik/blob/v3.6.12/CHANGELOG.md))
 - `gtfs-api`: upgrade [`postgrest/postgrest`](https://hub.docker.com/r/postgrest/postgrest) to [`v14.8`](https://github.com/PostgREST/postgrest/releases/tag/v14.8)
 - `gtfs-importer`: upgrade [`postgis-gtfs-importer`](https://github.com/mobidata-bw/postgis-gtfs-importer) to [`v5-2026-03-09T13.34.46-696778a`](https://github.com/mobidata-bw/postgis-gtfs-importer/tree/696778a)
+- ⚠️ `gtfs-db`: upgrade [`postgis-with-pg-plan-filter`](https://github.com/mobidata-bw/postgis-with-pg-plan-filter) to [`2026-04-08T15.38.33-3b74475`](https://github.com/mobidata-bw/postgis-with-pg-plan-filter/tree/3b74475) – Because this upgrades PostgreSQL to v18, to upgrade, you will have to
+  1. stop `gtfs-db` (`make docker-down SERVICE=gtfs-db`),
+  2. delete the DB directory (`rm -r var/gtfs/gtfs-db`),
+  3. apply the upgrade (`git pull`/`git checkout`),
+  4. restart `gtfs-db` (`make docker-up-detached SERVICE=gtfs-db`),
+  5. run a GTFS import (either using the Dagster UI or via `make import-new-gtfs`).
 - `sftp`: upgrade [`atmoz/sftp`](https://hub.docker.com/r/atmoz/sftp) to the latest ([`alpine`](https://hub.docker.com/layers/atmoz/sftp/alpine/images/sha256-56483e4d6678cbca5afccb1a6c525d95ba8f65dfb69063954a73317eda911579))
 - `pgbouncer`: upgrade to [`ghcr.io/mobidata-bw/pgbouncer:2026-01-03T04.37.53_afa4959`](https://github.com/mobidata-bw/bitnami-pgbouncer-image/tree/edae5705da14f318b39ee2c0517a951b18bd77a7), which is just a rebuild based on a new [`docker.io/bitnami/minideb:bookworm` base image](https://github.com/bitnami/containers/blob/afa495962f3fd58d0bbe4b02c9a70cb5dc66d0a2/bitnami/pgbouncer/1/debian-12/Dockerfile#L4C6-L4C40).
 


### PR DESCRIPTION
This PR is an alternative to #571, #572 and #179. It is breaking due to the `gtfs-db` (PostgreSQL v17) upgrade.