### PR TITLE
chore: bump geoserver to v2.27.1

### DIFF
--- a/.env
+++ b/.env
@@ -95,7 +95,7 @@ IPL_GTFS_API_DOCS_PORT=4001
 # Geoserver variables
 GEOSERVER_PROXY_BASE_URL=http://localhost:8600/geoserver
 GEOSERVER_CSRF_WHITELIST=mobidata-bw.de
-GEOSERVER_IMAGE=ghcr.io/mobidata-bw/ipl-geoserver:2.25.3
+GEOSERVER_IMAGE=ghcr.io/mobidata-bw/ipl-geoserver:2.27.1
 GEOSERVER_PORT=8600
 GEOSERVER_INITIAL_MEMORY=512M
 GEOSERVER_MAXIMUM_MEMORY=4G

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
+## Upcoming
+- Geoserver: Upgrade from 2.25.3 to 2.27.1 (see [geoserver/releases](https://github.com/geoserver/geoserver/releases/))
+
 ## 2025-08-05
 
 - [OCPDB 2.3.0](https://github.com/binary-butterfly/ocpdb/blob/44309e836c0c19d5e80d759c24321d940d55e820/CHANGELOG.md#version-230)


### PR DESCRIPTION
This PR bumps geoserver to v2.27.1. 

Tests on dev were successful, previews of all maps are working. No changes to config were necessary. 

closes https://github.com/mobidata-bw/ipl-orchestration/pull/428