### PR TITLE
pgbouncer: switch to bitnamilegacy/pgbouncer image

### DIFF
--- a/.env
+++ b/.env
@@ -77,7 +77,7 @@ IPL_GTFS_API_COST_LIMIT=3000000
 IPL_GTFS_DB_POSTGREST_USER=postgrest
 
 # pgbouncer variables
-PGBOUNCER_IMAGE=bitnami/pgbouncer:1
+PGBOUNCER_IMAGE=docker.io/bitnamilegacy/pgbouncer:1
 PGBOUNCER_POSTGRES_USER=postgres
 
 # gtfs-api variables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - `caddy`: upgrade [`caddy`](https://hub.docker.com/_/caddy) to [`2.10.2-alpine`](https://hub.docker.com/layers/library/caddy/2.10.2-alpine/images/sha256-e9fd95fd7cea0c3403c622c5c2457cddcaf355a5eba11048b17cb3d99a828f33) ([v2.10.1 release](https://github.com/caddyserver/caddy/releases/tag/v2.10.1), [v2.10.2 release](https://github.com/caddyserver/caddy/releases/tag/v2.10.2))
 - `gtfs-api-docs`: upgrade to [`skriptfabrik/elements-cli:0.5.21`](https://github.com/skriptfabrik/elements-cli/commits/0.5.21)
+- `pgbouncer`: switch to [`bitnamilegacy/pgbouncer` image](https://hub.docker.com/r/bitnamilegacy/pgbouncer)
+  - Follow [#422](https://github.com/mobidata-bw/ipl-orchestration/issues/422) for updates.
 
 ## 2025-09-16
 


### PR DESCRIPTION
As outlined in https://github.com/bitnami/containers/issues/83267#issue-3237062909, the `bitnami/pgbouncer:1` image is unavailable until 2025-09-19T10:00+02:00; It maybe permanently offline some time later.