### PR TITLE
chore: bump redis to latest version and run under local user

### DIFF
--- a/.env
+++ b/.env
@@ -23,6 +23,7 @@ LAMASSU_FEED_CACHE_MINIMUM_INTERVAL_IN_S=21600
 
 # redis variables
 REDIS_MEMORY_MB=1024
+REDIS_IMAGE=redis:8.2.2-alpine3.22
 
 # ipl-db variables
 IPL_POSTGIS_IMAGE=postgis/postgis:15-3.4-alpine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
-## unreleased
+## 2025-10-09
+- Internal: Redis Upgrade to 8.2.2.
 - Lamassu: Bump to [the 2025-10-06T15-58 release](https://github.com/entur/lamassu/releases/tag/2025-10-06T15-58), which (according to [changelog](https://github.com/entur/lamassu/blob/87727f50d4d3b4b39d3f234852b83133e5f14bc7/Changelog.md) includes:
   - Enable system hours to opening hours mapping (https://github.com/entur/lamassu/pull/715)
   - fix: handle duplicate entities gracefully with warning logs (https://github.com/entur/lamassu/pull/730)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -250,7 +250,8 @@ services:
 
   redis:
     networks: [ipl]
-    image: redis:8-alpine
+    user: *local-user
+    image: ${REDIS_IMAGE}
     # Redis tries to use all memory it gets, and doesn't query the container's memory limit.
     # see also https://stackoverflow.com/a/70779280
     # --save '' should explicitly disable saving to volume data, avoiding no space left on devide errors


### PR DESCRIPTION
This PR moves Redis image tag to `.env` and switches to a specific version (8.2.2).
The user running redis is switched to the local user.