### PR TITLE
gtfs-importer: fix import by upgrading

### DIFF
--- a/.env
+++ b/.env
@@ -55,7 +55,7 @@ IPL_GTFS_DB_POSTGRES_DB=gtfs_importer
 IPL_GTFS_DB_POSTGRES_DB_PREFIX=gtfs
 
 # gtfs-importer variables
-IPL_GTFS_IMPORTER_IMAGE=ghcr.io/mobidata-bw/postgis-gtfs-importer:v5-2025-10-22T10.41.11-588c98b
+IPL_GTFS_IMPORTER_IMAGE=ghcr.io/mobidata-bw/postgis-gtfs-importer:v5-2025-11-04t11.28.22-494c209
 IPL_GTFS_IMPORTER_GTFS_DOWNLOAD_URL=https://www.nvbw.de/fileadmin/user_upload/service/open_data/fahrplandaten_mit_liniennetz/bwgesamt.zip
 # To make the GTFS import work within NVBW's IT infrastructure, we must manually resolve the GTFS server's domain.
 # Here however, in the default configuration, we set a harmless entry (an RFC 6761 special-use domain) that shouldn't interfere with the IPL operation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
+
 - GeoServer layer `MobiData-BW:bicycle_service_points`: add style and change SRS to `EPSG:25832`
+- `gtfs-importer`: upgraded [`postgis-gtfs-importer`](https://github.com/mobidata-bw/postgis-gtfs-importer) to [`v5-2025-11-04t11.28.22-494c209`](https://github.com/mobidata-bw/postgis-gtfs-importer/tree/494c209) – This fixes the GTFS import on non-`linux/arm64` (e.g. `linux/amd64`) platforms.
 
 ## 2025-10-28
 


### PR DESCRIPTION
This PR fixes the GTFS import on `linux/amd64` platforms.

See also https://github.com/mobidata-bw/postgis-gtfs-importer/commit/333c435e830fdbd9ec68fc6c6f90261fbde2fcca.