### PR TITLE
Update CHANGELOG for release on 2025-11-05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
-## Unreleased
+## 2025-11-05
+
 - GeoServer layer `MobiData-BW:bicycle_service_points`: add style, change SRS to `EPSG:25832`, add attribute descriptions
 - `gtfs-importer`: upgraded [`postgis-gtfs-importer`](https://github.com/mobidata-bw/postgis-gtfs-importer) to [`v5-2025-11-04t11.28.22-494c209`](https://github.com/mobidata-bw/postgis-gtfs-importer/tree/494c209) – This fixes the GTFS import on non-`linux/arm64` (e.g. `linux/amd64`) platforms.
 - [ParkAPI 0.37.0](https://github.com/ParkenDD/park-api-v3/blob/33d4b0f3d1f81c89467017795a71492924a4e65e/CHANGELOG.md#0370)


### PR DESCRIPTION
Document notable changes for the release on 2025-11-05, including updates to GeoServer layer and gtfs-importer.