### PR TITLE
Renovate Bot: tweak `…_IMAGE` detection regex

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -19,7 +19,7 @@
 				// - `IPL_POSTGIS_IMAGE=postgis/postgis:15-3.3-alpine`
 				// - `SFTP_IMAGE=atmoz/sftp:alpine@sha256:61313b2ba0b9aa95a5bf5ff51386963219dd019ad9a7b5f4017bedf8d7309e11`
 				// this regex is adapted from https://github.com/renovatebot/.github/blob/ccec7065e1587f993a10cb5ae1bf31ff3bae7c4e/default.json#L165
-				"\\b\\w+_IMAGE=(?<packageName>[^:]+):(?<currentValue>[a-z0-9.-]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?\\b",
+				"\\b\\w+_IMAGE=(?<packageName>[^:]+):(?<currentValue>[a-z0-9.\\-]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?\\b",
 			],
 			"datasourceTemplate": "docker",
 		},

--- a/renovate.json5
+++ b/renovate.json5
@@ -19,7 +19,7 @@
 				// - `IPL_POSTGIS_IMAGE=postgis/postgis:15-3.3-alpine`
 				// - `SFTP_IMAGE=atmoz/sftp:alpine@sha256:61313b2ba0b9aa95a5bf5ff51386963219dd019ad9a7b5f4017bedf8d7309e11`
 				// this regex is adapted from https://github.com/renovatebot/.github/blob/ccec7065e1587f993a10cb5ae1bf31ff3bae7c4e/default.json#L165
-				"\\b\\w+_IMAGE=(?<packageName>[^:]+):(?<currentValue>[a-z0-9.\\-]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?\\b",
+				"\\b\\w+_IMAGE=(?<packageName>[^:]+):(?<currentValue>[A-Za-z0-9.\\-]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?\\b",
 			],
 			"datasourceTemplate": "docker",
 		},

--- a/renovate.json5
+++ b/renovate.json5
@@ -18,8 +18,9 @@
 				// - `TRANSFORMER_PROXY_IMAGE=ghcr.io/mobidata-bw/ipl-proxy:2024-04-23T16-02`
 				// - `IPL_POSTGIS_IMAGE=postgis/postgis:15-3.3-alpine`
 				// - `SFTP_IMAGE=atmoz/sftp:alpine@sha256:61313b2ba0b9aa95a5bf5ff51386963219dd019ad9a7b5f4017bedf8d7309e11`
+				// - `PGBOUNCER_IMAGE=ghcr.io/mobidata-bw/pgbouncer:2025-10-22T09.46.22_afa4959`
 				// this regex is adapted from https://github.com/renovatebot/.github/blob/ccec7065e1587f993a10cb5ae1bf31ff3bae7c4e/default.json#L165
-				"\\b\\w+_IMAGE=(?<packageName>[^:]+):(?<currentValue>[A-Za-z0-9.\\-]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?\\b",
+				"\\b\\w+_IMAGE=(?<packageName>[^:]+):(?<currentValue>[A-Za-z0-9.\\-_]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?\\b",
 			],
 			"datasourceTemplate": "docker",
 		},


### PR DESCRIPTION
Currently, Renovate Bot fails with some updates because it doesn't currectly understand the *current* version of an image:

```json5
DEBUG: packageFiles with updates
	[…]
	{
		"currentValue": "2025-12-",
		"currentVersion": "2025-12-",
		"datasource": "docker",
		"depName": "entur/lamassu",
		"fixedVersion": "2025-12-",
		"isSingleVersion": true,
		"packageName": "entur/lamassu",
		"registryUrl": "https://index.docker.io",
		"replaceString": "LAMASSU_IMAGE=entur/lamassu:2025-12-",
		"versioning": "loose",
		"warnings": [],
		"updates": [
			[…]
		]
	}
	[…]
[…]
DEBUG: Value is not updated (branch="renovate/entur-lamassu-2025.x")
	{
		"depName": "entur/lamassu",
		"manager": "regex",
		"packageFile": ".env",
		"expectedValue": "2025-12-29T06-55",
		"foundValue": "2025-12-"
	}
```

Now, the output looks like this:

```json5
DEBUG: packageFiles with updates (repository=local)
	[…]
	{
		"packageName": "entur/lamassu",
		"currentValue": "2025-12-08T06-47",
		"datasource": "docker",
		"replaceString": "LAMASSU_IMAGE=entur/lamassu:2025-12-08T06-47",
		"depName": "entur/lamassu",
		"updates": [
			[…]
		],
		"versioning": "loose",
		"warnings": [],
		"registryUrl": "https://index.docker.io",
		"currentVersion": "2025-12-08T06-47",
		"currentVersionTimestamp": "2025-12-08T06:48:07.277Z",
		"currentVersionAgeInDays": 121,
		"isSingleVersion": true,
		"fixedVersion": "2025-12-08T06-47"
	}
	[…]
```

You can test this be running Renovate Bot locally:
1. Generate a [fine-grained GitHub personal access token](https://github.com/settings/personal-access-tokens) and set it as `$GITHUB_TOKEN`.
2. Run `docker run --rm -it -v $PWD:/app -v /tmp/renovate:/tmp/renovate -e RENOVATE_BASE_DIR=/tmp/renovate -e LOG_LEVEL=debug -e RENOVATE_GITHUB_COM_TOKEN="$GITHUB_TOKEN" -w /app renovate/renovate --mode=silent --platform=local --dry-run=lookup` in `ipl-orchestration`.