### PR TITLE
Chore: bump lamassu pipeline redis geoserver

### DIFF
--- a/.env
+++ b/.env
@@ -97,7 +97,7 @@ IPL_GTFS_API_DOCS_PORT=4001
 # Geoserver variables
 GEOSERVER_PROXY_BASE_URL=http://localhost:8600/geoserver
 GEOSERVER_CSRF_WHITELIST=mobidata-bw.de
-GEOSERVER_IMAGE=ghcr.io/mobidata-bw/ipl-geoserver:2.28.1
+GEOSERVER_IMAGE=ghcr.io/mobidata-bw/ipl-geoserver:2.28.3
 GEOSERVER_PORT=8600
 GEOSERVER_INITIAL_MEMORY=512M
 GEOSERVER_MAXIMUM_MEMORY=4G

--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@ TZ=Europe/Berlin
 TRANSFORMER_PROXY_IMAGE=ghcr.io/mobidata-bw/ipl-proxy:2026-01-14T08-35
 TRANSFORMER_PROXY_PORT=8400
 
-LAMASSU_IMAGE=entur/lamassu:2025-12-08T06-47
+LAMASSU_IMAGE=entur/lamassu:2026-04-16T18-28
 LAMASSU_PORT=8500
 LAMASSU_ADMIN_PORT=9002
 LAMASSU_BASE_URL=http://localhost:8080/sharing
@@ -23,7 +23,7 @@ LAMASSU_FEED_CACHE_MINIMUM_INTERVAL_IN_S=21600
 
 # redis variables
 REDIS_MEMORY_MB=1024
-REDIS_IMAGE=redis:8.4.0-alpine3.22
+REDIS_IMAGE=redis:8.6.2-alpine3.23
 
 # ipl-db variables
 IPL_POSTGIS_IMAGE=postgis/postgis:15-3.5-alpine

--- a/.env
+++ b/.env
@@ -41,9 +41,9 @@ MIKAR_API_URL=https://mikar.fleetster.de
 
 # dagster variables
 DAGSTER_POSTGRES_IMAGE=postgres:15.12-bullseye
-DAGSTER_PIPELINE_IMAGE=ghcr.io/mobidata-bw/dagster-pipeline:2025-08-06T08-42
-DAGSTER_DAGIT_IMAGE=ghcr.io/mobidata-bw/dagster-dagit:2025-08-06T08-42
-DAGSTER_DAEMON_IMAGE=ghcr.io/mobidata-bw/dagster-daemon:2025-08-06T08-42
+DAGSTER_PIPELINE_IMAGE=ghcr.io/mobidata-bw/dagster-pipeline:2026-05-11t12-34
+DAGSTER_DAGIT_IMAGE=ghcr.io/mobidata-bw/dagster-dagit:2026-05-11t12-34
+DAGSTER_DAEMON_IMAGE=ghcr.io/mobidata-bw/dagster-daemon:2026-05-11t12-34
 DAGSTER_POSTGRES_USER=postgres_user
 DAGSTER_POSTGRES_DB=postgres_db
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+- [ipl dagster pipeline 2026-05-08](https://github.com/mobidata-bw/ipl-dagster-pipeline/blob/83fc1fe8f31449460b32a959226dbb91450de67b/CHANGELOG.md?plain=1#L7)
 - GeoServer: bump to 2.28.3
 - Lamassu:
   - Bump to [2026-04-16T18-28 release](https://github.com/entur/lamassu/blob/8707b2566cf0cddfb0855e595b72fdbaebfa6ad5/Changelog.md#130-under-development)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
-## [Unreleased]
+## Unreleased
 
+- GeoServer: bump to 2.28.3
 - Lamassu:
   - Bump to [2026-04-16T18-28 release](https://github.com/entur/lamassu/blob/8707b2566cf0cddfb0855e595b72fdbaebfa6ad5/Changelog.md#130-under-development)
   - Bump redis to [8.6.2-alpine3.23](https://github.com/redis/redis/releases/tag/8.6.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
+## [Unreleased]
+
+- Lamassu:
+  - Bump to [2026-04-16T18-28 release](https://github.com/entur/lamassu/blob/8707b2566cf0cddfb0855e595b72fdbaebfa6ad5/Changelog.md#130-under-development)
+  - Bump redis to [8.6.2-alpine3.23](https://github.com/redis/redis/releases/tag/8.6.2)
+
+
 ## 2026-05-06
 
 - GeoServer: use `LEFT JOIN` instead of `JOIN` to get information on the business for `MobiData-BW:charge_points`


### PR DESCRIPTION
This PR bumps lamassu, ipl-dagster-pipeline, redis and geoserver to current versions:

- [ipl dagster pipeline 2026-05-08](https://github.com/mobidata-bw/ipl-dagster-pipeline/blob/83fc1fe8f31449460b32a959226dbb91450de67b/CHANGELOG.md?plain=1#L7)
- GeoServer: bump to [2.28.3](https://github.com/geoserver/geoserver/releases/tag/2.28.3)
- Lamassu:
  - Bump to [2026-04-16T18-28 release](https://github.com/entur/lamassu/blob/8707b2566cf0cddfb0855e595b72fdbaebfa6ad5/Changelog.md#130-under-development)
  - Bump redis to [8.6.2-alpine3.23](https://github.com/redis/redis/releases/tag/8.6.2)
