### PR TITLE
tweak Renovate Bot config

### DIFF
--- a/.env
+++ b/.env
@@ -26,6 +26,7 @@ REDIS_MEMORY_MB=1024
 REDIS_IMAGE=redis:8.6.2-alpine3.23
 
 # ipl-db variables
+# Note: Renovate Bot is configured, using a custom versioning regex, to upgrade the PostgreSQL and PostGIS versions independently.
 IPL_POSTGIS_IMAGE=postgis/postgis:15-3.5-alpine
 IPL_POSTGRES_DB=geoserver
 IPL_POSTGRES_USER=geoserver

--- a/renovate.json5
+++ b/renovate.json5
@@ -42,6 +42,15 @@
 	        versioning: 'regex:^(?<major>\\d+)-(?<minor>\\d+)(\\.(?<patch>\\d+))?(-(?<compatibility>.*))?$',
 		},
 
+		// `ghcr.io/osgeo/gdal` has the "compatibility" part in the front and the version in the back, e.g. `alpine-small-3.12.1`
+		{
+			"matchDatasources": ["docker"],
+			"matchPackageNames": [
+				"ghcr.io/osgeo/gdal",
+			],
+	        versioning: 'regex:^(?<compatibility>[^\d]+)-(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?$',
+		},
+
 		// With a purely date-time-based tagging scheme (e.g. `2024-05-29T01.02`), the `docker` versioning scheme [1] doesn't seem to recognize newer tags as updates. For those images, we configure the `loose` versioning scheme [2], which recognizes newer tags as non-major updates.
 		// Note: `loose` detects the tag's date as the major version, so it will start *wrongly* detecting *major* updates whenever the year has changed.
 		// todo: configure this individually per image?

--- a/renovate.json5
+++ b/renovate.json5
@@ -26,6 +26,22 @@
 		},
 	],
 	"packageRules": [
+		// As of 2026-05-19, Renovate currently doesn't support tracking >1 versioning schemes at once.
+		// For example, `docker.io/postgis/postgis:15-3.5-alpine` uses PostgreSQL v15 with PostGIS v3.5 with Alpine Linux.
+		// This is why, as a workaround, we define
+		// - the PostgreSQL version as major,
+		// - the PostGIS version as minor/patch, and
+		// - the `alpine` suffix as "compatibility", to be kept in place by Renovate.
+		// https://github.com/renovatebot/renovate/discussions/15652
+		// https://github.com/renovatebot/renovate/discussions/41845
+		{
+			"matchDatasources": ["docker"],
+			"matchPackageNames": [
+				"docker.io/postgis/postgis",
+			],
+	        versioning: 'regex:^(?<major>\\d+)-(?<minor>\\d+)(\\.(?<patch>\\d+))?(-(?<compatibility>.*))?$',
+		},
+
 		// With a purely date-time-based tagging scheme (e.g. `2024-05-29T01.02`), the `docker` versioning scheme [1] doesn't seem to recognize newer tags as updates. For those images, we configure the `loose` versioning scheme [2], which recognizes newer tags as non-major updates.
 		// Note: `loose` detects the tag's date as the major version, so it will start *wrongly* detecting *major* updates whenever the year has changed.
 		// todo: configure this individually per image?

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,6 +3,9 @@
 	"extends": [
 		"config:recommended",
 	],
+	"labels": [
+		"dependencies"
+	],
 	"customManagers": [
 		// Renovate Bot's Docker Compose manager *does not* currently support resolving variables defined in `.env` and used in `docker-compose.yml`. However, we want to be able to use different images (tags) for a Compose service, depending on the deployment [1]. This is why we define a custom manager [2].
 		// Note: It only scans .env using regular expressions for aptly named variables, without any understanding for docker-compose.yml and wether this variable is actually used in a service's `image` field.


### PR DESCRIPTION
This PR restores Renovate Bot's functionality:
- For `docker.io/postgis/postgis` (`ipl-db`), it causes Renovate Bot to also submit PRs for PostGIS upgrades keeping the PostgreSQL major version (`15-3.4-alpine` -> `15-3.5-alpine`), instead of just upgrade PostGIS with major PostgreSQL upgrades.
- For `ghcr.io/osgeo/gdal` (`ocpdb-regionalschluessel-importer`), it makes Renovate Bot work with the unsual naming scheme (flavor/"compatibility" part first, version second).