### PR TITLE
Geoserver: fix log configuration and reduce verbosity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 - GeoServer: add `has_fee`, `fee_description` and `description` to `MobiData-BW:park-api_car_lines`
+- GeoServer: reduce log verbosity: mount log files to host volume, disable stdout logging and use PRODUCTION_LOGGING
 
 ## 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 - GeoServer: add `has_fee`, `fee_description` and `description` to `MobiData-BW:park-api_car_lines`
-- GeoServer: reduce log verbosity: mount log files to host volume, disable stdout logging and use PRODUCTION_LOGGING
+- ⚠️ GeoServer: tweak logging
+	- write logs to host directory `var/log/geoserver`
+	- reduce log verbosity switching to `PRODUCTION_LOGGING` profile
+	- disable stdout logging
 
 ## 2026-06-18
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ init: etc/sftp/users.conf etc/sftp/ssh_host_ed25519_key etc/sftp/ssh_host_rsa_ke
 	mkdir -p var/geoserver/datadir
 	touch -a var/geoserver/datadir/global.xml
 	mkdir -p var/geoserver/gwc_cache_dir
-	mkdir -p var/geoserver/logs
+	mkdir -p var/log/geoserver/tomcat
+	mkdir -p var/log/geoserver/geoserver
 	mkdir -p var/goaccess/data
 	mkdir -p var/goaccess/report
 	mkdir -p var/ocpdb/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -297,7 +297,8 @@ services:
     volumes:
       # var/geoserver defaults to geoserver/data_dir, custom config shall explicitly be defined in etc/geoserver
       - ./var/geoserver/datadir/:/var/geoserver/datadir/
-      - ./var/geoserver/logs/:/var/geoserver/logs/
+      - ./var/log/geoserver/tomcat/:/usr/local/tomcat/logs/
+      - ./var/log/geoserver/geoserver/:/var/geoserver/logs/
       - ./var/geoserver/gwc_cache_dir/:/var/geoserver/gwc_cache_dir/
       - ./etc/geoserver/:/var/geoserver/datadir_template/
       # global.xml is written by geoserver before config reload, so we need to have it mounted already at start
@@ -317,7 +318,6 @@ services:
       - INITIAL_MEMORY=${GEOSERVER_INITIAL_MEMORY}
       - MAXIMUM_MEMORY=${GEOSERVER_MAXIMUM_MEMORY}
       - GEOSERVER_DATA_DIR_CUSTOM=/var/geoserver/datadir_template/
-      - GEOSERVER_LOGGING_PROFILE=${GEOSERVER_LOGGING_PROFILE}
       - GEOSERVER_CSRF_WHITELIST=${GEOSERVER_CSRF_WHITELIST:?missing/empty}
       - PROXY_BASE_URL=${GEOSERVER_PROXY_BASE_URL:?missing/empty}
       # All we want to do is set user.timezone and DALLOW_ENV_PARAMETRIZATION. Due to https://github.com/geosolutions-it/docker-geoserver/issues/133
@@ -339,7 +339,6 @@ services:
           -XX:ConcGCThreads=5
           -Dorg.geotools.coverage.jaiext.enabled=$${JAIEXT_ENABLED}
           -Dorg.geotools.shapefile.datetime=true
-          -DGEOSERVER_LOG_LOCATION=$${GEOSERVER_LOG_LOCATION}
           -DGEOWEBCACHE_CONFIG_DIR=$${GEOWEBCACHE_CONFIG_DIR}
           -DGEOWEBCACHE_CACHE_DIR=$${GEOWEBCACHE_CACHE_DIR}
           -DNETCDF_DATA_DIR=$${NETCDF_DATA_DIR}

--- a/etc/geoserver/logging.xml
+++ b/etc/geoserver/logging.xml
@@ -1,7 +1,6 @@
-
 <logging>
-  <level>${GEOSERVER_LOGGING_PROFILE}</level>
-  <location>logs/geoserver.log</location>
+  <level>DEFAULT_LOGGING</level>
+  <location>/var/geoserver/logs/</location>
   <stdOutLogging>true</stdOutLogging>
 </logging>
 

--- a/etc/geoserver/logging.xml
+++ b/etc/geoserver/logging.xml
@@ -1,6 +1,5 @@
 <logging>
-  <level>DEFAULT_LOGGING</level>
+  <level>PRODUCTION_LOGGING</level>
   <location>/var/geoserver/logs/</location>
-  <stdOutLogging>true</stdOutLogging>
+  <stdOutLogging>false</stdOutLogging>
 </logging>
-


### PR DESCRIPTION
This PR
* Sets log level explicitly instead of a not extrapolated environment variable
* reduces log verbosity by explicitly configuration PRODUCTION_LOGGING
* mounts directories containing log files explicitly to `var/log/geoserver`
* disables stdout logging.
